### PR TITLE
Create Carousel widget - Part 2

### DIFF
--- a/examples/api/lib/material/carousel/carousel.0.dart
+++ b/examples/api/lib/material/carousel/carousel.0.dart
@@ -32,7 +32,7 @@ class CarouselExample extends StatefulWidget {
   State<CarouselExample> createState() => _CarouselExampleState();
 }
 
-class _CarouselExampleState extends State<CarouselExample> with SingleTickerProviderStateMixin {
+class _CarouselExampleState extends State<CarouselExample> {
   @override
   Widget build(BuildContext context) {
     return Center(

--- a/examples/api/lib/material/carousel/carousel.0.dart
+++ b/examples/api/lib/material/carousel/carousel.0.dart
@@ -1,0 +1,77 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+/// Flutter code sample for [Carousel].
+
+void main() => runApp(const CarouselExampleApp());
+
+class CarouselExampleApp extends StatelessWidget {
+  const CarouselExampleApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      home: Scaffold(
+        appBar: AppBar(
+          title: const Text('Carousel Sample'),
+        ),
+        body: const CarouselExample(),
+      ),
+    );
+  }
+}
+
+class CarouselExample extends StatefulWidget {
+  const CarouselExample({super.key});
+
+  @override
+  State<CarouselExample> createState() => _CarouselExampleState();
+}
+
+class _CarouselExampleState extends State<CarouselExample> with SingleTickerProviderStateMixin {
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxHeight: 200),
+        child: Carousel(
+          itemExtent: 330,
+          shrinkExtent: 200,
+          children: List<Widget>.generate(20, (int index){
+            return UncontainedLayoutCard(index: index, label: 'Item $index');
+          }),
+        ),
+      ),
+    );
+  }
+}
+
+class UncontainedLayoutCard extends StatelessWidget {
+  const UncontainedLayoutCard({
+    super.key,
+    required this.index,
+    required this.label,
+  });
+
+  final int index;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return ColoredBox(
+      color: Colors.primaries[index % Colors.primaries.length].withOpacity(0.5),
+      child: Center(
+        child: Text(
+          label,
+          style: const TextStyle(color: Colors.white, fontSize: 20),
+          overflow: TextOverflow.clip,
+          softWrap: false,
+        ),
+      ),
+    );
+  }
+}

--- a/examples/api/lib/material/carousel/carousel.0.dart
+++ b/examples/api/lib/material/carousel/carousel.0.dart
@@ -17,7 +17,14 @@ class CarouselExampleApp extends StatelessWidget {
       debugShowCheckedModeBanner: false,
       home: Scaffold(
         appBar: AppBar(
-          title: const Text('Carousel Sample'),
+          leading: const Icon(Icons.cast),
+          title: const Text('Flutter TV'),
+          actions: const <Widget>[
+            Padding(
+              padding: EdgeInsetsDirectional.only(end: 16.0),
+              child: CircleAvatar(child: Icon(Icons.account_circle)),
+            ),
+          ],
         ),
         body: const CarouselExample(),
       ),
@@ -33,19 +40,146 @@ class CarouselExample extends StatefulWidget {
 }
 
 class _CarouselExampleState extends State<CarouselExample> {
+  late final CarouselController controller;
+
+  @override
+  void initState() {
+    controller = CarouselController(initialItem: 1);
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    controller.dispose();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxHeight: 200),
-        child: Carousel(
-          itemExtent: 330,
-          shrinkExtent: 200,
-          children: List<Widget>.generate(20, (int index){
-            return UncontainedLayoutCard(index: index, label: 'Item $index');
-          }),
+    final double height = MediaQuery.sizeOf(context).height;
+
+    return ListView(
+      children: <Widget>[
+        ConstrainedBox(
+          constraints: BoxConstraints(maxHeight: height / 2),
+          child: Carousel.weighted(
+            controller: controller,
+            itemSnapping: true,
+            layoutWeights: const <int>[1,7,1],
+            children: ImageInfo.values.map((ImageInfo image) {
+              return HeroLayoutCard(imageInfo: image);
+            }).toList(),
+          ),
         ),
-      ),
+        const SizedBox(height: 20),
+        const Padding(
+          padding: EdgeInsetsDirectional.only(top: 8.0, start: 8.0),
+          child: Text('Multi-browse layout'),
+        ),
+        ConstrainedBox(
+          constraints: const BoxConstraints(maxHeight: 50),
+          child: Carousel.weighted(
+            layoutWeights: const <int>[1,2,3,2,1],
+            allowFullyExpand: false,
+            children: List<Widget>.generate(20, (int index) {
+              return ColoredBox(
+                color: Colors.primaries[index % Colors.primaries.length].withOpacity(0.8),
+                child: const SizedBox.expand(),
+              );
+            }),
+          ),
+        ),
+        const SizedBox(height: 20),
+        ConstrainedBox(
+          constraints: const BoxConstraints(maxHeight: 200),
+          child: Carousel.weighted(
+            layoutWeights: const <int>[3,3,3,2,1],
+            allowFullyExpand: false,
+            children: CardInfo.values.map((CardInfo info) {
+              return ColoredBox(
+                color: info.backgroundColor,
+                child: Center(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: <Widget>[
+                      Icon(info.icon, color: info.color, size: 32.0),
+                      Text(info.label, style: const TextStyle(fontWeight: FontWeight.bold), overflow: TextOverflow.clip, softWrap: false),
+                    ],
+                  ),
+                ),
+              );
+            }).toList()
+          ),
+        ),
+        const SizedBox(height: 20),
+        const Padding(
+          padding: EdgeInsetsDirectional.only(top: 8.0, start: 8.0),
+          child: Text('Uncontained layout'),
+        ),
+        ConstrainedBox(
+          constraints: const BoxConstraints(maxHeight: 200),
+          child: Carousel(
+            itemExtent: 330,
+            shrinkExtent: 200,
+            children: List<Widget>.generate(20, (int index){
+              return UncontainedLayoutCard(index: index, label: 'Show $index');
+            }),
+          ),
+        )
+      ],
+    );
+  }
+}
+
+class HeroLayoutCard extends StatelessWidget {
+  const HeroLayoutCard({
+    super.key,
+    required this.imageInfo,
+  });
+
+  final ImageInfo imageInfo;
+
+  @override
+  Widget build(BuildContext context) {
+    final double width = MediaQuery.sizeOf(context).width;
+    return Stack(
+      alignment: AlignmentDirectional.bottomStart,
+      children: <Widget>[
+        ClipRect(
+          child: OverflowBox(
+            maxWidth: width * 7 / 8,
+            minWidth: width * 7 / 8,
+            child: Image(
+              fit: BoxFit.cover,
+              image: NetworkImage(
+                'https://flutter.github.io/assets-for-api-docs/assets/material/${imageInfo.url}'
+              ),
+            ),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.all(18.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Text(
+                imageInfo.title,
+                overflow: TextOverflow.clip,
+                softWrap: false,
+                style: Theme.of(context).textTheme.headlineLarge?.copyWith(color: Colors.white),
+              ),
+              const SizedBox(height: 10),
+              Text(
+                imageInfo.subtitle,
+                overflow: TextOverflow.clip,
+                softWrap: false,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: Colors.white),
+              )
+            ],
+          ),
+        ),
+      ]
     );
   }
 }
@@ -74,4 +208,35 @@ class UncontainedLayoutCard extends StatelessWidget {
       ),
     );
   }
+}
+
+enum CardInfo {
+  camera('Cameras', Icons.video_call, Color(0xff2354C7), Color(0xffECEFFD)),
+  lighting('Lighting', Icons.lightbulb, Color(0xff806C2A), Color(0xffFAEEDF)),
+  climate('Climate', Icons.thermostat, Color(0xffA44D2A), Color(0xffFAEDE7)),
+  wifi('Wifi', Icons.wifi, Color(0xff417345), Color(0xffE5F4E0)),
+  media('Media', Icons.library_music, Color(0xff2556C8), Color(0xffECEFFD)),
+  security('Security', Icons.crisis_alert, Color(0xff794C01), Color(0xffFAEEDF)),
+  safety('Safety', Icons.medical_services, Color(0xff2251C5), Color(0xffECEFFD)),
+  more('', Icons.add, Color(0xff201D1C), Color(0xffE3DFD8));
+
+  const CardInfo(this.label, this.icon, this.color, this.backgroundColor);
+  final String label;
+  final IconData icon;
+  final Color color;
+  final Color backgroundColor;
+}
+
+enum ImageInfo {
+  image0('The Flow', 'Sponsored | Season 1 Now Streaming', 'content_based_color_scheme_1.png'),
+  image1('Through the Pane', 'Sponsored | Season 1 Now Streaming', 'content_based_color_scheme_2.png'),
+  image2('Iridescence', 'Sponsored | Season 1 Now Streaming', 'content_based_color_scheme_3.png'),
+  image3('Sea Change', 'Sponsored | Season 1 Now Streaming', 'content_based_color_scheme_4.png'),
+  image4('Blue Symphony', 'Sponsored | Season 1 Now Streaming', 'content_based_color_scheme_5.png'),
+  image5('When It Rains', 'Sponsored | Season 1 Now Streaming', 'content_based_color_scheme_6.png');
+
+  const ImageInfo(this.title, this.subtitle, this.url);
+  final String title;
+  final String subtitle;
+  final String url;
 }

--- a/examples/api/test/material/carousel/carousel.0_test.dart
+++ b/examples/api/test/material/carousel/carousel.0_test.dart
@@ -1,0 +1,16 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/carousel/carousel.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Carousel Smoke Test', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.CarouselExampleApp(),
+    );
+    expect(find.byType(Carousel), findsOneWidget);
+  });
+}

--- a/packages/flutter/lib/material.dart
+++ b/packages/flutter/lib/material.dart
@@ -46,6 +46,7 @@ export 'src/material/button_theme.dart';
 export 'src/material/calendar_date_picker.dart';
 export 'src/material/card.dart';
 export 'src/material/card_theme.dart';
+export 'src/material/carousel.dart';
 export 'src/material/checkbox.dart';
 export 'src/material/checkbox_list_tile.dart';
 export 'src/material/checkbox_theme.dart';

--- a/packages/flutter/lib/src/material/carousel.dart
+++ b/packages/flutter/lib/src/material/carousel.dart
@@ -378,7 +378,7 @@ class _RenderSliverFixedExtentCarousel extends RenderSliverFixedExtentBoxAdaptor
   }
 
   // This implements the [itemExtentBuilder] callback.
-  double _buildItemExtent(int index, SliverLayoutDimensions currentLayoutDimensions) {
+  double _buildItemExtent(int index, SliverLayoutDimensions _currentLayoutDimensions) {
     final int firstVisibleIndex = (constraints.scrollOffset / maxExtent).floor();
 
     // Calculate how many items have been completely scroll off screen.
@@ -409,6 +409,8 @@ class _RenderSliverFixedExtentCarousel extends RenderSliverFixedExtentBoxAdaptor
     return maxExtent;
   }
 
+  late SliverLayoutDimensions _currentLayoutDimensions;
+
   /// The layout offset for the child with the given index.
   @override
   double indexToLayoutOffset(
@@ -426,7 +428,7 @@ class _RenderSliverFixedExtentCarousel extends RenderSliverFixedExtentBoxAdaptor
     // least the remaining extent to make sure a smooth size transition.
     final double effectiveMinExtent = math.max(constraints.remainingPaintExtent % maxExtent, minExtent);
     if (index == firstVisibleIndex) {
-      final double firstVisibleItemExtent = _buildItemExtent(index, currentLayoutDimensions);
+      final double firstVisibleItemExtent = _buildItemExtent(index, _currentLayoutDimensions);
 
       // If the first item is squished to be less than `effectievMinExtent`,
       // then it should stop changinng its size and should start to scroll off screen.
@@ -731,12 +733,11 @@ class CarouselController extends ScrollController {
   ScrollPosition createScrollPosition(ScrollPhysics physics, ScrollContext context, ScrollPosition? oldPosition) {
     assert(_carouselState != null);
     final double? itemExtent = _carouselState!.itemExtent;
-    int expandedItem = initialItem;
 
     return _CarouselPosition(
       physics: physics,
       context: context,
-      initialItem: expandedItem,
+      initialItem: initialItem,
       itemExtent: itemExtent!,
       oldPosition: oldPosition,
     );

--- a/packages/flutter/lib/src/material/carousel.dart
+++ b/packages/flutter/lib/src/material/carousel.dart
@@ -218,7 +218,7 @@ class _CarouselState extends State<Carousel> {
 
   double? getItemExtent() {
     if (widget.itemExtent != null) {
-      final double screenExtent = switch(widget.scrollDirection) {
+      final double screenExtent = switch (widget.scrollDirection) {
         Axis.horizontal => MediaQuery.sizeOf(context).width,
         Axis.vertical => MediaQuery.sizeOf(context).height,
       };

--- a/packages/flutter/lib/src/material/carousel.dart
+++ b/packages/flutter/lib/src/material/carousel.dart
@@ -411,6 +411,17 @@ class _RenderSliverFixedExtentCarousel extends RenderSliverFixedExtentBoxAdaptor
 
   late SliverLayoutDimensions _currentLayoutDimensions;
 
+  @override
+  void performLayout() {
+    _currentLayoutDimensions = SliverLayoutDimensions(
+      scrollOffset: constraints.scrollOffset,
+      precedingScrollExtent: constraints.precedingScrollExtent,
+      viewportMainAxisExtent: constraints.viewportMainAxisExtent,
+      crossAxisExtent: constraints.crossAxisExtent,
+    );
+    super.performLayout();
+  }
+
   /// The layout offset for the child with the given index.
   @override
   double indexToLayoutOffset(

--- a/packages/flutter/lib/src/material/carousel.dart
+++ b/packages/flutter/lib/src/material/carousel.dart
@@ -378,7 +378,7 @@ class _RenderSliverFixedExtentCarousel extends RenderSliverFixedExtentBoxAdaptor
   }
 
   // This implements the [itemExtentBuilder] callback.
-  double _buildItemExtent(int index, SliverLayoutDimensions _currentLayoutDimensions) {
+  double _buildItemExtent(int index, SliverLayoutDimensions currentLayoutDimensions) {
     final int firstVisibleIndex = (constraints.scrollOffset / maxExtent).floor();
 
     // Calculate how many items have been completely scroll off screen.

--- a/packages/flutter/lib/src/material/carousel.dart
+++ b/packages/flutter/lib/src/material/carousel.dart
@@ -13,27 +13,29 @@ import 'ink_well.dart';
 import 'material.dart';
 import 'theme.dart';
 
-/// A Material Design carousel.
+/// A Material Design carousel widget.
 ///
-/// This is a scrollable list where the size of each item can change dynamically
-/// based on different layouts.
+/// Carousels present a scrollable list of items, each of which can dynamically
+/// change size based on the chosen layout.
 ///
-/// Material Design 3 introduces 4 layouts for [Carousel]:
+/// Material Design 3 introduces 4 [Carousel] layouts:
 ///  * Multi-browse: This layout shows at least one large, medium, and small
 /// carousel item at a time.
-///  * Uncontained: This layout show items that scroll to the edge of the container.
+///  * Uncontained (default): This layout show items that scroll to the edge of
+/// the container.
 ///  * Hero: This layout shows at least one large and one small item at a time.
 ///  * Full-screen: This layout shows one edge-to-edge large item at a time and
 /// scrolls vertically.
 ///
-/// By default, [Carousel] has a uncontained layout. It shows like a [ListView]
-/// and its children are a single size.
+/// By default, `Carousel` uses the uncontained layout, behaving similarly to a
+/// `ListView` where all children are a uniform size.
 ///
-/// The [CarouselController] can be used to control the [CarouselController.initialItem].
+/// The [CarouselController] is used to control the [CarouselController.initialItem].
 ///
-/// [Carousel.itemExtent] must be non-null. Even though the children [Carousel]
-/// have a single size, the first and last items can be squished a little while
-/// scrolling and the minimum squished size is determined by [shrinkExtent].
+/// The `Carousel.itemExtent` property must be non-null and defines the base
+/// size of items. While items typically maintain this size, the first and last
+/// visible items may be slightly compressed during scrolling. The `shrinkExtent`
+/// property controls the minimum allowable size for these compressed items.
 ///
 /// {@tool dartpad}
 /// Here is an example of [Carousel].
@@ -97,17 +99,20 @@ class Carousel extends StatefulWidget {
   ///   * focused - Theme.colorScheme.onSurface(0.1)
   final WidgetStateProperty<Color?>? overlayColor;
 
-  /// The minimum extent that each carousel item can be.
+  /// The minimum allowable extent (size) for carousel items during scrolling
+  /// transitions.
   ///
-  /// While scrolling, the first visible item will be pinned and keep shrinking
-  /// until this extent, then it is scrolled off screen; the last visible item
-  /// will show on screen with this size and keep expanding until the
-  /// [itemExtent]. So if this is 0.0, then the item should shrink/expand to/from
-  /// 0.0 from/to the [itemExtent].
+  /// As the carousel scrolls, the first visible item is pinned and gradually
+  /// shrinks until it reaches this minimum extent before scrolling off-screen.
+  /// Similarly, the last visible item enters the viewport at this minimum size
+  /// and expands to its full `itemExtent`.
   ///
-  /// However, if the remaining extent of the viewport for the last visible item
-  /// is bigger than [shrinkExtent], [shrinkExtent] will be adjusted to be the
-  /// remaining extent for a smooth size transition during scrolling.
+  /// A `shrinkExtent` of 0.0 allows items to shrink/expand completely, transitioning
+  /// between 0.0 and the full `itemExtent`.
+  ///
+  /// In cases where the remaining viewport space for the last visible item is
+  /// larger than the defined `shrinkExtent`, the `shrinkExtent` is dynamically
+  /// adjusted to match this remaining space, ensuring a smooth size transition.
   ///
   /// Defaults to 0.0.
   final double? shrinkExtent;
@@ -305,17 +310,19 @@ class _CarouselState extends State<Carousel> {
   }
 }
 
-// A sliver that places its box children in a linear array and constrains them
-// to have a fixed extent.
-//
-// _To learn more about slivers, see [CustomScrollView.slivers]._
-//
-// This sliver list arranges its children in a line along the main axis starting
-// at offset zero and without gaps. Each child is constrained to a fixed extent
-// along the main axis and the [SliverConstraints.crossAxisExtent]
-// along the cross axis. The difference between this and a list view with a fixed
-// extent is the first item and last item can be squished a little based on the
-// value of [minExtent], as the [Carousel spces](https://m3.material.io/components/carousel/guidelines#96c5c157-fe5b-4ee3-a9b4-72bf8efab7e9) indicates.
+/// A sliver that displays its box children in a linear array with a fixed extent
+/// per item.
+///
+/// _To learn more about slivers, see [CustomScrollView.slivers]._
+///
+/// This sliver list arranges its children in a line along the main axis starting
+/// at offset zero and without gaps. Each child is constrained to a fixed extent
+/// along the main axis and the [SliverConstraints.crossAxisExtent]
+/// along the cross axis. The difference between this and a list view with a fixed
+/// extent is the first item and last item can be squished a little during scrolling
+/// transition.This compression is controlled by the `minExtent` property and
+/// aligns with the [Material Design Carousel specifications]
+/// (https://m3.material.io/components/carousel/guidelines#96c5c157-fe5b-4ee3-a9b4-72bf8efab7e9).
 class _SliverFixedExtentCarousel extends SliverMultiBoxAdaptorWidget {
   const _SliverFixedExtentCarousel({
     required super.delegate,

--- a/packages/flutter/lib/src/material/carousel.dart
+++ b/packages/flutter/lib/src/material/carousel.dart
@@ -219,8 +219,8 @@ class _CarouselState extends State<Carousel> {
   double? getItemExtent() {
     if (widget.itemExtent != null) {
       final double screenExtent = switch(widget.scrollDirection) {
-        Axis.horizontal => MediaQuery.of(context).size.width,
-        Axis.vertical => MediaQuery.of(context).size.height,
+        Axis.horizontal => MediaQuery.sizeOf(context).width,
+        Axis.vertical => MediaQuery.sizeOf(context).height,
       };
 
       return clampDouble(widget.itemExtent!, 0, screenExtent);

--- a/packages/flutter/lib/src/material/carousel.dart
+++ b/packages/flutter/lib/src/material/carousel.dart
@@ -1,0 +1,744 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+
+import 'colors.dart';
+import 'ink_well.dart';
+import 'material.dart';
+import 'theme.dart';
+
+/// A Material Design carousel.
+///
+/// This is a scrollable list where the size of each item can change dynamically
+/// based on different layouts.
+///
+/// Material Design 3 introduces 4 layouts for [Carousel]:
+///  * Multi-browse: This layout shows at least one large, medium, and small
+/// carousel item at a time.
+///  * Uncontained: This layout show items that scroll to the edge of the container.
+///  * Hero: This layout shows at least one large and one small item at a time.
+///  * Full-screen: This layout shows one edge-to-edge large item at a time and
+/// scrolls vertically.
+///
+/// By default, [Carousel] has a uncontained layout. It shows like a [ListView]
+/// and its children are a single size.
+///
+/// The [CarouselController] can be used to control the [CarouselController.initialItem].
+///
+/// [Carousel.itemExtent] must be non-null. Even though the children [Carousel]
+/// have a single size, the first and last items can be squished a little while
+/// scrolling and the minimum squished size is determined by [shrinkExtent].
+///
+/// {@tool dartpad}
+/// Here is an example of [Carousel].
+///
+/// ** See code in examples/api/lib/material/carousel/carousel.0.dart **
+/// {@end-tool}
+///
+/// See also:
+///
+///  * [CarouselController], which controls which item is the first visible in
+/// the view.
+///  * [PageView], which is a scrollable list that works page by page.
+class Carousel extends StatefulWidget {
+  /// Creates a Material Design carousel.
+  const Carousel({
+    super.key,
+    this.padding,
+    this.backgroundColor,
+    this.elevation,
+    this.shape,
+    this.overlayColor,
+    this.itemSnapping = false,
+    this.shrinkExtent,
+    this.controller,
+    this.scrollDirection = Axis.horizontal,
+    this.reverse = false,
+    this.onTap,
+    required this.itemExtent,
+    required this.children,
+  });
+
+  /// The amount of space to surround each carousel item with.
+  ///
+  /// Defaults to EdgeInsets.all(4.0).
+  final EdgeInsets? padding;
+
+  /// The background color for each carousel item.
+  ///
+  /// Defaults to [ColorScheme.surface].
+  final Color? backgroundColor;
+
+  /// The z-coordinate of each carousel item.
+  ///
+  /// Defaults to 0.0.
+  final double? elevation;
+
+  /// The shape of each carousel item's [Material].
+  ///
+  /// Defines each item's [Material.shape].
+  ///
+  /// Defaults to a [RoundedRectangleBorder] with a circular corner radius
+  /// of 28.0.
+  final ShapeBorder? shape;
+
+  /// The highlight color to indicate the carousel items are in pressed, hovered
+  /// or focused states.
+  ///
+  /// The default values are:
+  ///   * pressed - Theme.colorScheme.onSurface(0.1)
+  ///   * hovered - Theme.colorScheme.onSurface(0.08)
+  ///   * focused - Theme.colorScheme.onSurface(0.1)
+  final WidgetStateProperty<Color?>? overlayColor;
+
+  /// The minimum extent that each carousel item can be.
+  ///
+  /// While scrolling, the first visible item will be pinned and keep shrinking
+  /// until this extent, then it is scrolled off screen; the last visible item
+  /// will show on screen with this size and keep expanding until the
+  /// [itemExtent]. So if this is 0.0, then the item should shrink/expand to/from
+  /// 0.0 from/to the [itemExtent].
+  ///
+  /// However, if the remaining extent of the viewport for the last visible item
+  /// is bigger than [shrinkExtent], [shrinkExtent] will be adjusted to be the
+  /// remaining extent for a smooth size transition during scrolling.
+  ///
+  /// Defaults to 0.0.
+  final double? shrinkExtent;
+
+  /// Whether the carousel should keep scrolling to the next/previous items to
+  /// maintain the original layout.
+  ///
+  /// Defaults to false.
+  final bool itemSnapping;
+
+  /// An object that can be used to control the position to which this scroll
+  /// view is scrolled.
+  final CarouselController? controller;
+
+  /// The [Axis] along which the scroll view's offset increases with each page.
+  ///
+  /// Defaults to [Axis.horizontal].
+  final Axis scrollDirection;
+
+  /// Whether the carousel list scrolls in the reading direction.
+  ///
+  /// For example, if the reading direction is left-to-right and
+  /// [scrollDirection] is [Axis.horizontal], then the carousel scrolls from
+  /// left to right when [reverse] is false and from right to left when
+  /// [reverse] is true.
+  ///
+  /// Similarly, if [scrollDirection] is [Axis.vertical], then the page view
+  /// scrolls from top to bottom when [reverse] is false and from bottom to top
+  /// when [reverse] is true.
+  ///
+  /// Defaults to false.
+  final bool reverse;
+
+  /// Called when one of the [children] is tapped.
+  final ValueChanged<int>? onTap;
+
+  /// The extent the children are forced to have in the main axis.
+  final double? itemExtent;
+
+  /// The child widgets for carousel.
+  final List<Widget> children;
+
+  @override
+  State<Carousel> createState() => _CarouselState();
+}
+
+class _CarouselState extends State<Carousel> {
+  late double? itemExtent;
+  CarouselController? _internalController;
+  CarouselController get _controller => widget.controller ?? _internalController!;
+
+  @override
+  void initState() {
+    if (widget.controller == null) {
+      _internalController = CarouselController();
+    }
+    _controller._attach(this);
+    super.initState();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    itemExtent = getItemExtent();
+  }
+
+  @override
+  void didUpdateWidget(covariant Carousel oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.controller != oldWidget.controller) {
+      oldWidget.controller?._detach(this);
+      if (widget.controller != null) {
+        _internalController?._detach(this);
+        _internalController = null;
+        widget.controller?._attach(this);
+      }
+    }
+    if (widget.itemExtent != oldWidget.itemExtent) {
+      itemExtent = getItemExtent();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller._detach(this);
+    if (widget.controller == null) {
+      _controller.dispose();
+    }
+    super.dispose();
+  }
+
+  AxisDirection _getDirection(BuildContext context) {
+    switch (widget.scrollDirection) {
+      case Axis.horizontal:
+        assert(debugCheckHasDirectionality(context));
+        final TextDirection textDirection = Directionality.of(context);
+        final AxisDirection axisDirection = textDirectionToAxisDirection(textDirection);
+        return widget.reverse ? flipAxisDirection(axisDirection) : axisDirection;
+      case Axis.vertical:
+        return widget.reverse ? AxisDirection.up : AxisDirection.down;
+    }
+  }
+
+  double? getItemExtent() {
+    if (widget.itemExtent != null) {
+      final double screenExtent = switch(widget.scrollDirection) {
+        Axis.horizontal => MediaQuery.of(context).size.width,
+        Axis.vertical => MediaQuery.of(context).size.height,
+      };
+
+      return clampDouble(widget.itemExtent!, 0, screenExtent);
+    }
+    return null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final AxisDirection axisDirection = _getDirection(context);
+    final ScrollPhysics physics = widget.itemSnapping
+      ? const CarouselScrollPhysics()
+      : ScrollConfiguration.of(context).getScrollPhysics(context);
+    final EdgeInsets effectivePadding = widget.padding ?? const EdgeInsets.all(4.0);
+    final Color effectiveBackgroundColor = widget.backgroundColor ?? Theme.of(context).colorScheme.surface;
+    final double effectiveElevation = widget.elevation ?? 0.0;
+    final ShapeBorder effectiveShape = widget.shape
+      ?? const RoundedRectangleBorder(
+        borderRadius: BorderRadius.all(Radius.circular(28.0))
+      );
+
+    final List<Widget> children = List<Widget>.generate(widget.children.length, (int index) {
+      return Padding(
+        padding: effectivePadding,
+        child: Material(
+          clipBehavior: Clip.antiAlias,
+          color: effectiveBackgroundColor,
+          elevation: effectiveElevation,
+          shape: effectiveShape,
+          child: Stack(
+            fit: StackFit.expand,
+            children: <Widget>[
+              widget.children.elementAt(index),
+              Material(
+                color: Colors.transparent,
+                child: InkWell(
+                  onTap: () {
+                    widget.onTap?.call(index);
+                  },
+                  overlayColor: widget.overlayColor ?? WidgetStateProperty.resolveWith((Set<WidgetState> states) {
+                    if (states.contains(WidgetState.pressed)) {
+                      return theme.colorScheme.onSurface.withOpacity(0.1);
+                    }
+                    if (states.contains(WidgetState.hovered)) {
+                      return theme.colorScheme.onSurface.withOpacity(0.08);
+                    }
+                    if (states.contains(WidgetState.focused)) {
+                      return theme.colorScheme.onSurface.withOpacity(0.1);
+                    }
+                    return null;
+                  }),
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    });
+
+    return Scrollable(
+      axisDirection: axisDirection,
+      controller: _controller,
+      physics: physics,
+      viewportBuilder: (BuildContext context, ViewportOffset position) {
+        return Viewport(
+          cacheExtent: 0.0,
+          cacheExtentStyle: CacheExtentStyle.viewport,
+          axisDirection: axisDirection,
+          offset: position,
+          clipBehavior: Clip.antiAlias,
+          slivers: <Widget>[
+            _SliverFixedExtentCarousel(
+              itemExtent: itemExtent!,
+              minExtent: widget.shrinkExtent ?? 0.0,
+              delegate: SliverChildBuilderDelegate(
+                (BuildContext context, int index) {
+                  return children.elementAt(index);
+                },
+                childCount: children.length,
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+// A sliver that places its box children in a linear array and constrains them
+// to have a fixed extent.
+//
+// _To learn more about slivers, see [CustomScrollView.slivers]._
+//
+// This sliver list arranges its children in a line along the main axis starting
+// at offset zero and without gaps. Each child is constrained to a fixed extent
+// along the main axis and the [SliverConstraints.crossAxisExtent]
+// along the cross axis. The difference between this and a list view with a fixed
+// extent is the first item and last item can be squished a little based on the
+// value of [minExtent], as the [Carousel spces](https://m3.material.io/components/carousel/guidelines#96c5c157-fe5b-4ee3-a9b4-72bf8efab7e9) indicates.
+class _SliverFixedExtentCarousel extends SliverMultiBoxAdaptorWidget {
+  const _SliverFixedExtentCarousel({
+    required super.delegate,
+    required this.minExtent,
+    required this.itemExtent,
+  });
+
+  final double itemExtent;
+  final double minExtent;
+
+  @override
+  RenderSliverFixedExtentBoxAdaptor createRenderObject(BuildContext context) {
+    final SliverMultiBoxAdaptorElement element = context as SliverMultiBoxAdaptorElement;
+    return _RenderSliverFixedExtentCarousel(
+      childManager: element,
+      minExtent: minExtent,
+      maxExtent: itemExtent,
+    );
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, _RenderSliverFixedExtentCarousel renderObject) {
+    renderObject.maxExtent = itemExtent;
+  }
+}
+
+class _RenderSliverFixedExtentCarousel extends RenderSliverFixedExtentBoxAdaptor {
+  _RenderSliverFixedExtentCarousel({
+    required super.childManager,
+    required double maxExtent,
+    required double minExtent,
+  }) : _maxExtent = maxExtent,
+       _minExtent = minExtent;
+
+  double get maxExtent => _maxExtent;
+  double _maxExtent;
+  set maxExtent(double value) {
+    if (_maxExtent == value) {
+      return;
+    }
+    _maxExtent = value;
+    markNeedsLayout();
+  }
+
+  double get minExtent => _minExtent;
+  double _minExtent;
+  set minExtent(double value) {
+    if (_minExtent == value) {
+      return;
+    }
+    _minExtent = value;
+    markNeedsLayout();
+  }
+
+  // This implements the [itemExtentBuilder] callback.
+  double _buildItemExtent(int index, SliverLayoutDimensions currentLayoutDimensions) {
+    final int firstVisibleIndex = (constraints.scrollOffset / maxExtent).floor();
+
+    // Calculate how many items have been completely scroll off screen.
+    final int offscreenItems = (constraints.scrollOffset / maxExtent).floor();
+
+    // If there is an item is partually off screen and partually on screen, `constraints.scrollOffset`
+    // must be greater than `offscreenItems * maxExtent`, so the difference
+    // between these two is how much the current first visible item is off screen.
+    final double offscreenExtent = constraints.scrollOffset - offscreenItems * maxExtent;
+
+    // If there is not enough space to place the last visible item but the remaining
+    // space is larger than `minExtent`, the extent for last item should be at
+    // least the remaining extent to make sure a smooth size transition.
+    final double effectiveMinExtent = math.max(constraints.remainingPaintExtent % maxExtent, minExtent);
+
+    // Two special handles are the first and last visible items. Other items' extent
+    // should all return `maxExtent`.
+    if (index == firstVisibleIndex) {
+      final double effectiveExtent = maxExtent - offscreenExtent;
+      return math.max(effectiveExtent, effectiveMinExtent);
+    }
+
+    final double scrollOffsetForLastIndex = constraints.scrollOffset + constraints.remainingPaintExtent;
+    if (index == getMaxChildIndexForScrollOffset(scrollOffsetForLastIndex, maxExtent)) {
+      return clampDouble(scrollOffsetForLastIndex - maxExtent * index, effectiveMinExtent, maxExtent);
+    }
+
+    return maxExtent;
+  }
+
+  /// The layout offset for the child with the given index.
+  @override
+  double indexToLayoutOffset(
+    @Deprecated(
+      'The itemExtent is already available within the scope of this function. '
+      'This feature was deprecated after v3.20.0-7.0.pre.'
+    )
+    double itemExtent,
+    int index,
+  ) {
+    final int firstVisibleIndex = (constraints.scrollOffset / maxExtent).floor();
+
+    // If there is not enough space to place the last visible item but the remaining
+    // space is larger than `minExtent`, the extent for last item should be at
+    // least the remaining extent to make sure a smooth size transition.
+    final double effectiveMinExtent = math.max(constraints.remainingPaintExtent % maxExtent, minExtent);
+    if (index == firstVisibleIndex) {
+      final double firstVisibleItemExtent = _buildItemExtent(index, currentLayoutDimensions);
+
+      // If the first item is squished to be less than `effectievMinExtent`,
+      // then it should stop changinng its size and should start to scroll off screen.
+      if (firstVisibleItemExtent <= effectiveMinExtent) {
+        return maxExtent * index - effectiveMinExtent + maxExtent;
+      }
+      return constraints.scrollOffset;
+    }
+    return maxExtent * index;
+  }
+
+  /// The minimum child index that is visible at the given scroll offset.
+  @override
+  int getMinChildIndexForScrollOffset(
+    double scrollOffset,
+    @Deprecated(
+      'The itemExtent is already available within the scope of this function. '
+      'This feature was deprecated after v3.20.0-7.0.pre.'
+    )
+    double itemExtent,
+  ) {
+    final int firstVisibleIndex = (constraints.scrollOffset / maxExtent).floor();
+    return math.max(firstVisibleIndex, 0);
+  }
+
+  /// The maximum child index that is visible at the given scroll offset.
+  @override
+  int getMaxChildIndexForScrollOffset(
+    double scrollOffset,
+    @Deprecated(
+      'The itemExtent is already available within the scope of this function. '
+      'This feature was deprecated after v3.20.0-7.0.pre.'
+    )
+    double itemExtent,
+  ) {
+    if (maxExtent > 0.0) {
+      final double actual = scrollOffset / maxExtent - 1;
+      final int round = actual.round();
+      if ((actual * maxExtent - round * maxExtent).abs() < precisionErrorTolerance) {
+        return math.max(0, round);
+      }
+      return math.max(0, actual.ceil());
+    }
+    return 0;
+  }
+
+  @override
+  double? get itemExtent => null;
+
+  @override
+  ItemExtentBuilder? get itemExtentBuilder => _buildItemExtent;
+}
+
+/// Scroll physics used by a [Carousel].
+///
+/// These physics cause the carousel item to snap to item boundaries.
+///
+/// See also:
+///
+///  * [ScrollPhysics], the base class which defines the API for scrolling
+///    physics.
+///  * [PageScrollPhysics], scroll physics used by a [PageView].
+class CarouselScrollPhysics extends ScrollPhysics {
+  /// Creates physics for a [Carousel].
+  const CarouselScrollPhysics({super.parent});
+
+  @override
+  CarouselScrollPhysics applyTo(ScrollPhysics? ancestor) {
+    return CarouselScrollPhysics(parent: buildParent(ancestor));
+  }
+
+  double _getTargetPixels(
+    _CarouselPosition position,
+    Tolerance tolerance,
+    double velocity,
+  ) {
+    double fraction;
+    fraction = position.itemExtent! / position.viewportDimension;
+
+    final double itemWidth = position.viewportDimension * fraction;
+
+    final double actual = math.max(0.0, position.pixels) / itemWidth;
+    final double round = actual.roundToDouble();
+    double item;
+    if ((actual - round).abs() < precisionErrorTolerance) {
+      item = round;
+    }
+    else {
+      item = actual;
+    }
+    if (velocity < -tolerance.velocity) {
+      item -= 0.5;
+    } else if (velocity > tolerance.velocity) {
+      item += 0.5;
+    }
+    return item.roundToDouble() * itemWidth;
+  }
+
+  @override
+  Simulation? createBallisticSimulation(
+    ScrollMetrics position,
+    double velocity,
+  ) {
+    assert(
+      position is _CarouselPosition,
+      'CarouselScrollPhysics can only be used with Scrollables that uses '
+      'the CarouselController',
+    );
+
+    final _CarouselPosition metrics = position as _CarouselPosition;
+    if ((velocity <= 0.0 && metrics.pixels <= metrics.minScrollExtent) ||
+        (velocity >= 0.0 && metrics.pixels >= metrics.maxScrollExtent)) {
+      return super.createBallisticSimulation(metrics, velocity);
+    }
+
+    final Tolerance tolerance = toleranceFor(metrics);
+    final double target = _getTargetPixels(metrics, tolerance, velocity);
+    if (target != metrics.pixels) {
+      return ScrollSpringSimulation(
+        spring,
+        metrics.pixels,
+        target,
+        velocity,
+        tolerance: tolerance,
+      );
+    }
+    return null;
+  }
+
+  @override
+  bool get allowImplicitScrolling => true;
+}
+
+/// Metrics for a [Carousel].
+class _CarouselMetrics extends FixedScrollMetrics {
+  /// Creates an immutable snapshot of values associated with a [Carousel].
+  _CarouselMetrics({
+    required super.minScrollExtent,
+    required super.maxScrollExtent,
+    required super.pixels,
+    required super.viewportDimension,
+    required super.axisDirection,
+    this.itemExtent,
+    required super.devicePixelRatio,
+  });
+
+  @override
+  _CarouselMetrics copyWith({
+    double? minScrollExtent,
+    double? maxScrollExtent,
+    double? pixels,
+    double? viewportDimension,
+    AxisDirection? axisDirection,
+    double? itemExtent,
+    double? devicePixelRatio,
+  }) {
+    return _CarouselMetrics(
+      minScrollExtent: minScrollExtent ?? (hasContentDimensions ? this.minScrollExtent : null),
+      maxScrollExtent: maxScrollExtent ?? (hasContentDimensions ? this.maxScrollExtent : null),
+      pixels: pixels ?? (hasPixels ? this.pixels : null),
+      viewportDimension: viewportDimension ?? (hasViewportDimension ? this.viewportDimension : null),
+      axisDirection: axisDirection ?? this.axisDirection,
+      itemExtent: itemExtent ?? this.itemExtent,
+      devicePixelRatio: devicePixelRatio ?? this.devicePixelRatio,
+    );
+  }
+
+  /// Extent for carousel item.
+  ///
+  /// Used to compute the first item from the current [pixels].
+  final double? itemExtent;
+}
+
+
+class _CarouselPosition extends ScrollPositionWithSingleContext implements _CarouselMetrics {
+  _CarouselPosition({
+    required super.physics,
+    required super.context,
+    this.initialItem = 0,
+    required double itemExtent,
+    super.oldPosition,
+  }) : _itemExtent = itemExtent,
+       _itemToShowOnStartup = initialItem.toDouble(),
+       super(
+         initialPixels: null
+       );
+
+  final int initialItem;
+  final double _itemToShowOnStartup;
+  // When the viewport has a zero-size, the `page` can not
+  // be retrieved by `getPageFromPixels`, so we need to cache the page
+  // for use when resizing the viewport to non-zero next time.
+  double? _cachedItem;
+
+  @override
+  double? get itemExtent => _itemExtent;
+  double? _itemExtent;
+  set itemExtent(double? value) {
+    if (_itemExtent == value) {
+      return;
+    }
+    _itemExtent = value;
+  }
+
+  double getItemFromPixels(double pixels, double viewportDimension) {
+    assert(viewportDimension > 0.0);
+    final double fraction = itemExtent! / viewportDimension;
+
+    final double actual = math.max(0.0, pixels) / (viewportDimension * fraction);
+    final double round = actual.roundToDouble();
+    if ((actual - round).abs() < precisionErrorTolerance) {
+      return round;
+    }
+    return actual;
+  }
+
+  double getPixelsFromItem(double item) {
+    final double fraction = itemExtent! / viewportDimension;
+
+    return item * viewportDimension * fraction;
+  }
+
+  @override
+  bool applyViewportDimension(double viewportDimension) {
+    final double? oldViewportDimensions = hasViewportDimension ? this.viewportDimension : null;
+    if (viewportDimension == oldViewportDimensions) {
+      return true;
+    }
+    final bool result = super.applyViewportDimension(viewportDimension);
+    final double? oldPixels = hasPixels ? pixels : null;
+    double item;
+    if (oldPixels == null) {
+      item = _itemToShowOnStartup;
+    } else if (oldViewportDimensions == 0.0) {
+      // If resize from zero, we should use the _cachedItem to recover the state.
+      item = _cachedItem!;
+    } else {
+      item = getItemFromPixels(oldPixels, oldViewportDimensions!);
+    }
+    final double newPixels = getPixelsFromItem(item);
+    // If the viewportDimension is zero, cache the page
+    // in case the viewport is resized to be non-zero.
+    _cachedItem = (viewportDimension == 0.0) ? item : null;
+
+    if (newPixels != oldPixels) {
+      correctPixels(newPixels);
+      return false;
+    }
+    return result;
+  }
+
+  @override
+  _CarouselMetrics copyWith({
+    double? minScrollExtent,
+    double? maxScrollExtent,
+    double? pixels,
+    double? viewportDimension,
+    AxisDirection? axisDirection,
+    double? itemExtent,
+    List<int>? layoutWeights,
+    double? devicePixelRatio,
+  }) {
+    return _CarouselMetrics(
+      minScrollExtent: minScrollExtent ?? (hasContentDimensions ? this.minScrollExtent : null),
+      maxScrollExtent: maxScrollExtent ?? (hasContentDimensions ? this.maxScrollExtent : null),
+      pixels: pixels ?? (hasPixels ? this.pixels : null),
+      viewportDimension: viewportDimension ?? (hasViewportDimension ? this.viewportDimension : null),
+      axisDirection: axisDirection ?? this.axisDirection,
+      itemExtent: itemExtent ?? this.itemExtent,
+      devicePixelRatio: devicePixelRatio ?? this.devicePixelRatio,
+    );
+  }
+}
+
+/// A controller for [Carousel].
+///
+/// Using a carousel controller helps to show which item is fully expanded on
+/// the carousel list.
+class CarouselController extends ScrollController {
+  /// Creates a carousel controller.
+  CarouselController({
+    this.initialItem = 0,
+  });
+
+  /// The item that expands to the maximum size when first creating the [Carousel].
+  final int initialItem;
+
+  _CarouselState? _carouselState;
+
+  // ignore: use_setters_to_change_properties
+  void _attach(_CarouselState anchor) {
+    _carouselState = anchor;
+  }
+
+  void _detach(_CarouselState anchor) {
+    if (_carouselState == anchor) {
+      _carouselState = null;
+    }
+  }
+
+  @override
+  ScrollPosition createScrollPosition(ScrollPhysics physics, ScrollContext context, ScrollPosition? oldPosition) {
+    assert(_carouselState != null);
+    final double? itemExtent = _carouselState!.itemExtent;
+    int expandedItem = initialItem;
+
+    return _CarouselPosition(
+      physics: physics,
+      context: context,
+      initialItem: expandedItem,
+      itemExtent: itemExtent!,
+      oldPosition: oldPosition,
+    );
+  }
+
+  @override
+  void attach(ScrollPosition position) {
+    super.attach(position);
+    final _CarouselPosition carouselPosition = position as _CarouselPosition;
+    carouselPosition.itemExtent = _carouselState!.itemExtent;
+  }
+}

--- a/packages/flutter/lib/src/material/carousel.dart
+++ b/packages/flutter/lib/src/material/carousel.dart
@@ -152,7 +152,7 @@ class Carousel extends StatefulWidget {
   /// The extent the children are forced to have in the main axis.
   final double? itemExtent;
 
-  /// The child widgets for carousel.
+  /// The child widgets for the carousel.
   final List<Widget> children;
 
   @override
@@ -596,12 +596,11 @@ class _CarouselMetrics extends FixedScrollMetrics {
     );
   }
 
-  /// Extent for carousel item.
+  /// Extent for the carousel item.
   ///
   /// Used to compute the first item from the current [pixels].
   final double? itemExtent;
 }
-
 
 class _CarouselPosition extends ScrollPositionWithSingleContext implements _CarouselMetrics {
   _CarouselPosition({

--- a/packages/flutter/lib/src/material/carousel.dart
+++ b/packages/flutter/lib/src/material/carousel.dart
@@ -4,6 +4,7 @@
 
 import 'dart:math' as math;
 
+import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
@@ -28,9 +29,29 @@ import 'theme.dart';
 /// scrolls vertically.
 ///
 /// By default, `Carousel` uses the uncontained layout, behaving similarly to a
-/// `ListView` where all children are a uniform size.
+/// `ListView` where all children are a uniform size. [Carousel.weighted] enables
+/// dynamic item sizing. Each item is assigned a weight that determines the
+/// portion of the viewport it occupies. This allows you to easily create layouts
+/// like multi-browse, hero, and full-screen.
 ///
-/// The [CarouselController] is used to control the [CarouselController.initialItem].
+/// Weights are relative proportions. For example, if the layout weights is
+/// [3,2,1], it means the first visible item occupies 3/6 of the viewport; the
+/// second visible item occupies 2/6 of the viewport; the last visible item
+/// occupies 1/6 of the viewport.
+///
+/// As the carousel scrolls, the size of the latter one gradually changes to
+/// the size of the former one. As a result, when the first visible item is
+/// completely off-screen, the following items should stay the same layout as
+/// before. Using [Carousel.weighted] helps build the multi-browse, hero,
+/// center-aligned hero and full-screen layouts, as indicated in
+/// [Carousel sepcs](https://m3.material.io/components/carousel/specs).
+///
+/// The [CarouselController] is used to control the
+/// [CarouselController.initialItem], which determines the first fully expanded
+/// item when the [Carousel] is initially displayed. For example, if the layout
+/// weights is [1, 2, 3, 2, 1] and the initial item is 4 (the fourth item), the
+/// list will display items 2, 3, 4, 5, and 6 in the view with weights 1, 2, 3,
+/// 2 and 1 respectively.
 ///
 /// The `Carousel.itemExtent` property must be non-null and defines the base
 /// size of items. While items typically maintain this size, the first and last
@@ -38,15 +59,16 @@ import 'theme.dart';
 /// property controls the minimum allowable size for these compressed items.
 ///
 /// {@tool dartpad}
-/// Here is an example of [Carousel].
+/// Here is an example of [Carousel]. This example shows different layouts that
+/// [Carousel] and [Carousel.weighted] can build.
 ///
 /// ** See code in examples/api/lib/material/carousel/carousel.0.dart **
 /// {@end-tool}
 ///
 /// See also:
 ///
-///  * [CarouselController], which controls which item is the first visible in
-/// the view.
+///  * [CarouselController], which controls which item is the first fully visible
+/// in the view.
 ///  * [PageView], which is a scrollable list that works page by page.
 class Carousel extends StatefulWidget {
   /// Creates a Material Design carousel.
@@ -65,7 +87,38 @@ class Carousel extends StatefulWidget {
     this.onTap,
     required this.itemExtent,
     required this.children,
-  });
+  }) : allowFullyExpand = true,
+       layoutWeights = null;
+
+/// Creates a scrollable list where the size of each child widget is dynamically
+/// determined by the provided `layoutWeights`.
+///
+/// The `layoutWeights` parameter is required and defines the relative size
+/// proportions of each child widget.
+///
+/// When `allowFullyExpand` is set to `true`, each child can be expanded to its
+/// maximum size while scrolling. For example, with `layoutWeights` of `[1, 7, 1]`,
+/// the initial weight of the first item is 1. However, by enabling
+/// `allowFullyExpand` and scrolling forward, the first item can expand to occupy
+/// a weight of 7, leaving a weight of 1 as white space before it. This feature
+/// is particularly useful for achieving "hero" and "center-aligned hero" layouts.
+  const Carousel.weighted({
+    super.key,
+    this.padding,
+    this.backgroundColor,
+    this.elevation,
+    this.shape,
+    this.overlayColor,
+    this.itemSnapping = false,
+    this.shrinkExtent,
+    this.controller,
+    this.scrollDirection = Axis.horizontal,
+    this.reverse = false,
+    this.allowFullyExpand = true,
+    this.onTap,
+    required this.layoutWeights,
+    required this.children,
+  }) : itemExtent = null;
 
   /// The amount of space to surround each carousel item with.
   ///
@@ -146,11 +199,36 @@ class Carousel extends StatefulWidget {
   /// Defaults to false.
   final bool reverse;
 
+  /// Whether we allow the "squished" item to expand to the max size.
+  ///
+  /// If this is false, the layout of the carousel doesn't change. This is especially
+  /// useful when a weight list for [Carousel.weighted] has a max item in the
+  /// middle and at least one small item on each side, such as [1, 7, 1],
+  /// the first and the last item cannot expand to the max size. If this is true,
+  /// there will be some space before/after the first/last item coming so every
+  /// items have a chance to be fully expanded.
+  ///
+  /// Defaults to true.
+  final bool allowFullyExpand;
+
   /// Called when one of the [children] is tapped.
   final ValueChanged<int>? onTap;
 
   /// The extent the children are forced to have in the main axis.
+  ///
+  /// This is required for uncontained layout. For [Carousel.weighted], this is null.
   final double? itemExtent;
+
+  /// The weights that each visible child should occupy the viewport.
+  ///
+  /// The length of [layoutWeights] means how many items we want to lay out on
+  /// the viewport. For example, setting [layoutWeights] to `<int>[3,2,1]` means
+  /// there are 3 carousel items and their extents are 3/6, 2/6 and 1/6 of the
+  /// viewport extent.
+  ///
+  /// This is a required property when [Carousel.weighted] is used. This is null
+  /// for default [Carousel].
+  final List<int>? layoutWeights;
 
   /// The child widgets for the carousel.
   final List<Widget> children;
@@ -161,11 +239,14 @@ class Carousel extends StatefulWidget {
 
 class _CarouselState extends State<Carousel> {
   late double? itemExtent;
+  late List<int>? weights;
   CarouselController? _internalController;
   CarouselController get _controller => widget.controller ?? _internalController!;
+  late bool allowFullyExpand;
 
   @override
   void initState() {
+    weights = widget.layoutWeights;
     if (widget.controller == null) {
       _internalController = CarouselController();
     }
@@ -176,6 +257,7 @@ class _CarouselState extends State<Carousel> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
+    allowFullyExpand = widget.allowFullyExpand;
     itemExtent = getItemExtent();
   }
 
@@ -189,6 +271,9 @@ class _CarouselState extends State<Carousel> {
         _internalController = null;
         widget.controller?._attach(this);
       }
+    }
+    if (widget.layoutWeights != oldWidget.layoutWeights) {
+      weights = widget.layoutWeights;
     }
     if (widget.itemExtent != oldWidget.itemExtent) {
       itemExtent = getItemExtent();
@@ -293,9 +378,20 @@ class _CarouselState extends State<Carousel> {
           offset: position,
           clipBehavior: Clip.antiAlias,
           slivers: <Widget>[
-            _SliverFixedExtentCarousel(
+            if (itemExtent != null) _SliverFixedExtentCarousel(
               itemExtent: itemExtent!,
               minExtent: widget.shrinkExtent ?? 0.0,
+              delegate: SliverChildBuilderDelegate(
+                (BuildContext context, int index) {
+                  return children.elementAt(index);
+                },
+                childCount: children.length,
+              ),
+            ),
+            if (weights != null) _SliverWeightedCarousel(
+              allowFullyExpand: allowFullyExpand,
+              shrinkExtent: widget.shrinkExtent ?? 0.0,
+              weights: weights!,
               delegate: SliverChildBuilderDelegate(
                 (BuildContext context, int index) {
                   return children.elementAt(index);
@@ -493,6 +589,506 @@ class _RenderSliverFixedExtentCarousel extends RenderSliverFixedExtentBoxAdaptor
   ItemExtentBuilder? get itemExtentBuilder => _buildItemExtent;
 }
 
+/// A sliver that arranges its box children in a linear array, constraining them
+/// to specific weights determined by the [weights] property.
+///
+/// _To learn more about slivers, see [CustomScrollView.slivers]._
+///
+/// This sliver arranges its children in a line along the main axis, starting
+/// at offset zero without gaps. Each child is constrained to its corresponding
+/// weight along the main axis and to the [SliverConstraints.crossAxisExtent]
+/// along the cross axis.
+///
+/// While scrolling, the extent (size) of each visible item changes dynamically
+/// based on the scrolling progress.  As the first visible item scrolls completely
+/// off-screen, the next item becomes the first visible item, and has the same
+/// size as the previously first item. The rest of the visible items maintain
+/// their relative layout.
+///
+/// For example, the layout weights is [1, 6, 1]. The length of [weights] array
+/// indicates three items should be visible at a time. The layout of these items
+/// would be:
+///  * First item: Extent is (1 / (1 + 6 + 1)) * viewport extent.
+///  * Second item: Extent is (6 / (1 + 6 + 1)) * viewport extent.
+///  * Third item: Extent is (1 / (1 + 6 + 1)) * viewport extent.
+///
+/// Assuming a viewport extent of 800 in the main axis and the first item is
+/// item 0, there would be three visible items with extents of 100, 600, and 100.
+/// As item 0 scrolls off-screen, the extent of item 1 smoothly decreases from 600
+/// to 100. For instance, if item 0 is 30% off-screen, item 1 should have decreased
+/// its size to 30% of the difference from 600 to 100; its extent would be
+/// 600 - 0.3 * (600 - 100). Similarly, item 2's extent would increase from 100
+/// to 600, becoming 100 + 0.3 * (600 - 100).
+///
+/// As the initially visible items change size during scrolling, item 3 enters
+/// the view to fill the remaining space. Its extent starts at a minimum of
+/// [shrinkExtent] (or 0 if [shrinkExtent] is not provided) and gradually
+/// increases to match the extent of the last visible item (100 in this example).
+class _SliverWeightedCarousel extends SliverMultiBoxAdaptorWidget {
+  const _SliverWeightedCarousel({
+    required super.delegate,
+    required this.allowFullyExpand,
+    required this.shrinkExtent,
+    required this.weights,
+  });
+
+  // Determine whether extra scroll offset should be calculate so that every
+  // item have a chance to scroll to the maximum extent.
+  //
+  // This is useful when the leading/trailing items has smaller weights than
+  // the middle items, such as [1,7], [3,2,1].
+  final bool allowFullyExpand;
+
+  // The starting extent for items when they gradually show on/off screen.
+  //
+  // This is useful to avoid a hairline shape. This value should also smaller
+  // than the last item extent to make sure a smooth transition. So in calculation,
+  // this is limited to [0, weight for the last visible item].
+  final double shrinkExtent;
+
+  // The layout arrangement.
+  //
+  // When items are laying out, each item will be arranged based on the order of
+  // the weights and the extent is based on the corresponding weight out of the
+  // sum of weights. The length of weights means how many items we can put in the
+  // view at a time.
+  final List<int> weights;
+
+  @override
+  RenderSliverFixedExtentBoxAdaptor createRenderObject(BuildContext context) {
+    final SliverMultiBoxAdaptorElement element = context as SliverMultiBoxAdaptorElement;
+    return _RenderSliverWeightedCarousel(
+      childManager: element,
+      allowFullyExpand: allowFullyExpand,
+      shrinkExtent: shrinkExtent,
+      weights: weights,
+    );
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, _RenderSliverWeightedCarousel renderObject) {
+    renderObject.allowFullyExpand = allowFullyExpand;
+    renderObject.shrinkExtent = shrinkExtent;
+    renderObject.weights = weights;
+  }
+}
+
+// A sliver that places its box children in a linear array and constrains them
+// to have the corresponding weight which is determined by [weights].
+class _RenderSliverWeightedCarousel extends RenderSliverFixedExtentBoxAdaptor {
+  _RenderSliverWeightedCarousel({
+    required super.childManager,
+    required bool allowFullyExpand,
+    required double shrinkExtent,
+    required List<int> weights,
+  }) : _allowFullyExpand = allowFullyExpand,
+       _shrinkExtent = shrinkExtent,
+       _weights = weights;
+
+  bool get allowFullyExpand => _allowFullyExpand;
+  bool _allowFullyExpand;
+  set allowFullyExpand(bool value) {
+    if (_allowFullyExpand == value) {
+      return;
+    }
+    _allowFullyExpand = value;
+    markNeedsLayout();
+  }
+
+  double get shrinkExtent => _shrinkExtent;
+  double _shrinkExtent;
+  set shrinkExtent(double value) {
+    if (_shrinkExtent == value) {
+      return;
+    }
+    _shrinkExtent = value;
+    markNeedsLayout();
+  }
+
+  List<int> get weights => _weights;
+  List<int> _weights;
+  set weights(List<int> value) {
+    if (_weights == value) {
+      return;
+    }
+    _weights = value;
+    markNeedsLayout();
+  }
+
+  late SliverLayoutDimensions _currentLayoutDimensions;
+
+  // This is to implement the itemExtentBuilder callback to return each item extent
+  // while scrolling.
+  //
+  // The given `index` is compared with `_firstVisibleItemIndex` to know how
+  // many items are placed before the current one in the view.
+  double _buildItemExtent(int index, SliverLayoutDimensions currentLayoutDimensions) {
+    double extent;
+    if (index == _firstVisibleItemIndex) {
+      extent = math.max(_distanceToLeadingEdge, effectiveShrinkExtent);
+    }
+
+    // Calculate the extents of items located within the range defined by the
+    // weights array relative to the first visible item. This allows us to
+    // precisely determine each item's extent based on its initial extent
+    // (calculated from the weights) and the scrolling progress (the off-screen
+    // portion of the first item).
+    else if (index > _firstVisibleItemIndex
+      && index - _firstVisibleItemIndex + 1 <= weights.length
+    ) {
+      assert(index - _firstVisibleItemIndex < weights.length);
+      final int currIndexOnWeightList = index - _firstVisibleItemIndex;
+      final int currWeight = weights.elementAt(currIndexOnWeightList);
+      extent = extentUnit * currWeight; // initial extent
+      final double progress = _firstVisibleItemOffscreenExtent / firstChildExtent;
+
+      final int prevWeight = weights.elementAt(currIndexOnWeightList - 1);
+      final double finalIncrease = (prevWeight - currWeight) / weights.max;
+      extent = extent + finalIncrease * progress * maxChildExtent;
+    }
+    // Calculate the extents of items located beyond the range defined by the
+    // weights array relative to the first visible item. During scrolling transiton,
+    // it is possible that the number of visible items is larger than the length
+    // of `weights`. The extra item extent should be calculated here to fill
+    // the remaining space.
+    else if (index > _firstVisibleItemIndex
+      && index - _firstVisibleItemIndex + 1 > weights.length)
+    {
+      double visibleItemsTotalExtent = _distanceToLeadingEdge;
+      for (int i = _firstVisibleItemIndex + 1; i < index; i++) {
+        visibleItemsTotalExtent += _buildItemExtent(i, currentLayoutDimensions);
+      }
+      extent = math.max(constraints.remainingPaintExtent - visibleItemsTotalExtent, effectiveShrinkExtent);
+    }
+    else {
+      extent = math.max(minChildExtent, effectiveShrinkExtent);
+    }
+    return extent;
+  }
+
+  // To ge the extent unit based on the viewport exten and the sum of weights.
+  double get extentUnit => constraints.viewportMainAxisExtent / (weights.reduce((int total, int extent) => total + extent));
+
+  double get firstChildExtent => weights.first * extentUnit;
+  double get maxChildExtent => weights.max * extentUnit;
+  double get minChildExtent => weights.min * extentUnit;
+
+  // The shrink extent for first and last visible items should be no larger
+  // than [minChildExtent] to ensure a smooth transition.
+  double get effectiveShrinkExtent => clampDouble(shrinkExtent, 0, minChildExtent);
+
+  // The index of the first visible item. The returned value can be negative when
+  // the leading items with smaller weights need to be fully expanded. For example,
+  // assuming a weights [1, 7, 1], when item 0 is expanding to the maximum size
+  // (with weight 7), we leave some space before item 0 assuming there is another
+  // item -1 as the first visible item.
+  int get _firstVisibleItemIndex {
+    int smallerWeightCount = 0;
+    for (final int weight in weights) {
+      if (weight == weights.max) {
+        break;
+      }
+      smallerWeightCount += 1;
+    }
+    int index;
+
+    final double actual = constraints.scrollOffset / firstChildExtent;
+    final int round = (constraints.scrollOffset / firstChildExtent).round();
+    if ((actual - round).abs() < precisionErrorTolerance) {
+      index = round;
+    } else {
+      index = actual.floor();
+    }
+    return allowFullyExpand ? index - smallerWeightCount : index;
+  }
+
+
+  // This value indicates the scrolling progress of items following the first
+  // item. It informs them how much the first item has moved off-screen,
+  // enabling them to adjust their sizes (grow or shrink) accordingly.
+  double get _firstVisibleItemOffscreenExtent {
+    int index;
+    final double actual = constraints.scrollOffset / firstChildExtent;
+    final int round = (constraints.scrollOffset / firstChildExtent).round();
+    if ((actual - round).abs() < precisionErrorTolerance) {
+      index = round;
+    } else {
+      index = actual.floor();
+    }
+    return constraints.scrollOffset - index * firstChildExtent;
+  }
+
+  // Given the off-screen extent for the first visible item, we can know the
+  // on-screen extent for the first visible item.
+  double get _distanceToLeadingEdge => firstChildExtent - _firstVisibleItemOffscreenExtent;
+
+  // Given an index, this method returns the layout offset for the item. The `index`
+  // is firstly compared to `_firstVisibleItemIndex` and compute the distance
+  // between them, then compute all the current extents for items that are located
+  // in front.
+  @override
+  double indexToLayoutOffset(
+    @Deprecated(
+      'The itemExtent is already available within the scope of this function. '
+      'This feature was deprecated after v3.20.0-7.0.pre.'
+    )
+    double itemExtent,
+    int index,
+  ) {
+    if (index == _firstVisibleItemIndex) {
+      if (_distanceToLeadingEdge <= effectiveShrinkExtent) {
+        return constraints.scrollOffset - effectiveShrinkExtent + _distanceToLeadingEdge;
+      }
+      return constraints.scrollOffset;
+    }
+    double visibleItemsTotalExtent = _distanceToLeadingEdge;
+    for (int i = _firstVisibleItemIndex + 1; i < index; i++) {
+      visibleItemsTotalExtent += _buildItemExtent(i, _currentLayoutDimensions);
+    }
+    return constraints.scrollOffset + visibleItemsTotalExtent;
+  }
+
+  @override
+  int getMinChildIndexForScrollOffset(
+    double scrollOffset,
+    @Deprecated(
+      'The itemExtent is already available within the scope of this function. '
+      'This feature was deprecated after v3.20.0-7.0.pre.'
+    )
+    double itemExtent,
+  ) {
+    return math.max(_firstVisibleItemIndex, 0);
+  }
+
+  @override
+  int getMaxChildIndexForScrollOffset(
+    double scrollOffset,
+    @Deprecated(
+      'The itemExtent is already available within the scope of this function. '
+      'This feature was deprecated after v3.20.0-7.0.pre.'
+    )
+    double itemExtent,
+  ) {
+    final int? childCount = childManager.estimatedChildCount;
+    if (childCount != null) {
+      double visibleItemsTotalExtent = _distanceToLeadingEdge;
+      for (int i = _firstVisibleItemIndex + 1; i < childCount; i++) {
+        visibleItemsTotalExtent += _buildItemExtent(i, _currentLayoutDimensions);
+        if (visibleItemsTotalExtent >= constraints.viewportMainAxisExtent) {
+          return i;
+        }
+      }
+    }
+    return childCount ?? 0;
+  }
+
+  @override
+  double computeMaxScrollOffset(
+    SliverConstraints constraints,
+    @Deprecated(
+      'The itemExtent is already available within the scope of this function. '
+      'This feature was deprecated after v3.20.0-7.0.pre.'
+    )
+    double itemExtent,
+  ) {
+    return childManager.childCount * maxChildExtent;
+  }
+
+  BoxConstraints _getChildConstraints(int index) {
+    double extent;
+    extent = itemExtentBuilder!(index, _currentLayoutDimensions)!;
+    return constraints.asBoxConstraints(
+      minExtent: extent,
+      maxExtent: extent,
+    );
+  }
+
+  // This method is mostly the same as its parent class [RenderSliverFixedExtentList].
+  // The difference is when we allow some space before the leading items or after
+  // the trailing items with smaller weights, we leave extra scroll offset.
+  @override
+  void performLayout() {
+    assert((itemExtent != null && itemExtentBuilder == null) ||
+        (itemExtent == null && itemExtentBuilder != null));
+    assert(itemExtentBuilder != null || (itemExtent!.isFinite && itemExtent! >= 0));
+
+    final SliverConstraints constraints = this.constraints;
+    childManager.didStartLayout();
+    childManager.setDidUnderflow(false);
+
+    final double scrollOffset = constraints.scrollOffset + constraints.cacheOrigin;
+    assert(scrollOffset >= 0.0);
+    final double remainingExtent = constraints.remainingCacheExtent;
+    assert(remainingExtent >= 0.0);
+    final double targetEndScrollOffset = scrollOffset + remainingExtent;
+    _currentLayoutDimensions = SliverLayoutDimensions(
+      scrollOffset: constraints.scrollOffset,
+      precedingScrollExtent: constraints.precedingScrollExtent,
+      viewportMainAxisExtent: constraints.viewportMainAxisExtent,
+      crossAxisExtent: constraints.crossAxisExtent
+    );
+    // TODO(Piinks): Clean up when deprecation expires.
+    const double deprecatedExtraItemExtent = -1;
+
+    final int firstIndex = getMinChildIndexForScrollOffset(scrollOffset, deprecatedExtraItemExtent);
+    final int? targetLastIndex = targetEndScrollOffset.isFinite ?
+        getMaxChildIndexForScrollOffset(targetEndScrollOffset, deprecatedExtraItemExtent) : null;
+
+    if (firstChild != null) {
+      final int leadingGarbage = calculateLeadingGarbage(firstIndex: firstIndex);
+      final int trailingGarbage = targetLastIndex != null ? calculateTrailingGarbage(lastIndex: targetLastIndex) : 0;
+      collectGarbage(leadingGarbage, trailingGarbage);
+    } else {
+      collectGarbage(0, 0);
+    }
+
+    if (firstChild == null) {
+      final double layoutOffset = indexToLayoutOffset(deprecatedExtraItemExtent, firstIndex);
+      if (!addInitialChild(index: firstIndex, layoutOffset: layoutOffset)) {
+        // There are either no children, or we are past the end of all our children.
+        final double max;
+        if (firstIndex <= 0) {
+          max = 0.0;
+        } else {
+          max = computeMaxScrollOffset(constraints, deprecatedExtraItemExtent);
+        }
+        geometry = SliverGeometry(
+          scrollExtent: max,
+          maxPaintExtent: max,
+        );
+        childManager.didFinishLayout();
+        return;
+      }
+    }
+
+    RenderBox? trailingChildWithLayout;
+
+    for (int index = indexOf(firstChild!) - 1; index >= firstIndex; --index) {
+      final RenderBox? child = insertAndLayoutLeadingChild(_getChildConstraints(index));
+      if (child == null) {
+        // Items before the previously first child are no longer present.
+        // Reset the scroll offset to offset all items prior and up to the
+        // missing item. Let parent re-layout everything.
+        geometry = SliverGeometry(scrollOffsetCorrection: indexToLayoutOffset(deprecatedExtraItemExtent, index));
+        return;
+      }
+      final SliverMultiBoxAdaptorParentData childParentData = child.parentData! as SliverMultiBoxAdaptorParentData;
+      childParentData.layoutOffset = indexToLayoutOffset(deprecatedExtraItemExtent, index);
+      assert(childParentData.index == index);
+      trailingChildWithLayout ??= child;
+    }
+
+    if (trailingChildWithLayout == null) {
+      firstChild!.layout(_getChildConstraints(indexOf(firstChild!)));
+      final SliverMultiBoxAdaptorParentData childParentData = firstChild!.parentData! as SliverMultiBoxAdaptorParentData;
+      childParentData.layoutOffset = indexToLayoutOffset(deprecatedExtraItemExtent, firstIndex);
+      trailingChildWithLayout = firstChild;
+    }
+
+    // From the last item to the firstly encountered max item
+    double extraLayoutOffset = 0;
+    if (allowFullyExpand) {
+      for (int i = weights.length - 1; i >= 0; i--) {
+        if (weights.elementAt(i) == weights.max) {
+          break;
+        }
+        extraLayoutOffset += weights.elementAt(i) * extentUnit;
+      }
+    }
+
+    double estimatedMaxScrollOffset = double.infinity;
+    // Layout visible items after the first visible item.
+    for (int index = indexOf(trailingChildWithLayout!) + 1; targetLastIndex == null || index <= targetLastIndex; ++index) {
+      RenderBox? child = childAfter(trailingChildWithLayout!);
+      if (child == null || indexOf(child) != index) {
+        child = insertAndLayoutChild(_getChildConstraints(index), after: trailingChildWithLayout);
+        if (child == null) {
+          // We have run out of children.
+          estimatedMaxScrollOffset = indexToLayoutOffset(deprecatedExtraItemExtent, index) + extraLayoutOffset;
+          break;
+        }
+      } else {
+        child.layout(_getChildConstraints(index));
+      }
+      trailingChildWithLayout = child;
+      final SliverMultiBoxAdaptorParentData childParentData = child.parentData! as SliverMultiBoxAdaptorParentData;
+      assert(childParentData.index == index);
+      childParentData.layoutOffset = indexToLayoutOffset(deprecatedExtraItemExtent, childParentData.index!);
+    }
+
+    final int lastIndex = indexOf(lastChild!);
+    final double leadingScrollOffset = indexToLayoutOffset(deprecatedExtraItemExtent, firstIndex);
+    double trailingScrollOffset;
+
+    if (lastIndex + 1 == childManager.childCount) {
+      trailingScrollOffset = indexToLayoutOffset(deprecatedExtraItemExtent, lastIndex);
+
+      trailingScrollOffset += math.max(weights.last * extentUnit, _buildItemExtent(lastIndex, _currentLayoutDimensions));
+      trailingScrollOffset += extraLayoutOffset;
+    } else {
+      trailingScrollOffset = indexToLayoutOffset(deprecatedExtraItemExtent, lastIndex + 1);
+    }
+
+    assert(debugAssertChildListIsNonEmptyAndContiguous());
+    assert(indexOf(firstChild!) == firstIndex);
+    assert(targetLastIndex == null || lastIndex <= targetLastIndex);
+
+    estimatedMaxScrollOffset = math.min(
+      estimatedMaxScrollOffset,
+      estimateMaxScrollOffset(
+        constraints,
+        firstIndex: firstIndex,
+        lastIndex: lastIndex,
+        leadingScrollOffset: leadingScrollOffset,
+        trailingScrollOffset: trailingScrollOffset,
+      ),
+    );
+
+    final double paintExtent = calculatePaintOffset(
+      constraints,
+      from: allowFullyExpand ? 0 : leadingScrollOffset,
+      to: trailingScrollOffset,
+    );
+
+    final double cacheExtent = calculateCacheOffset(
+      constraints,
+      from: allowFullyExpand ? 0 : leadingScrollOffset,
+      to: trailingScrollOffset,
+    );
+
+    final double targetEndScrollOffsetForPaint = constraints.scrollOffset + constraints.remainingPaintExtent;
+    final int? targetLastIndexForPaint = targetEndScrollOffsetForPaint.isFinite ?
+        getMaxChildIndexForScrollOffset(targetEndScrollOffsetForPaint, deprecatedExtraItemExtent) : null;
+
+    geometry = SliverGeometry(
+      scrollExtent: estimatedMaxScrollOffset,
+      paintExtent: paintExtent,
+      cacheExtent: cacheExtent,
+      maxPaintExtent: estimatedMaxScrollOffset,
+      // Conservative to avoid flickering away the clip during scroll.
+      hasVisualOverflow: (targetLastIndexForPaint != null && lastIndex >= targetLastIndexForPaint)
+        || constraints.scrollOffset > 0.0,
+    );
+
+    // We may have started the layout while scrolled to the end, which would not
+    // expose a new child.
+    if (estimatedMaxScrollOffset == trailingScrollOffset) {
+      childManager.setDidUnderflow(true);
+    }
+    childManager.didFinishLayout();
+  }
+
+  @override
+  double? get itemExtent => null;
+
+  /// The main-axis extent builder of each item.
+  ///
+  /// If this is non-null, the [itemExtent] must be null.
+  /// If this is null, the [itemExtent] must be non-null.
+  @override
+  ItemExtentBuilder? get itemExtentBuilder => _buildItemExtent;
+}
+
 /// Scroll physics used by a [Carousel].
 ///
 /// These physics cause the carousel item to snap to item boundaries.
@@ -517,7 +1113,12 @@ class CarouselScrollPhysics extends ScrollPhysics {
     double velocity,
   ) {
     double fraction;
-    fraction = position.itemExtent! / position.viewportDimension;
+    if (position.itemExtent != null) {
+      fraction = position.itemExtent! / position.viewportDimension;
+    } else {
+      assert(position.layoutWeights != null);
+      fraction = position.layoutWeights!.first / position.layoutWeights!.sum;
+    }
 
     final double itemWidth = position.viewportDimension * fraction;
 
@@ -583,6 +1184,7 @@ class _CarouselMetrics extends FixedScrollMetrics {
     required super.viewportDimension,
     required super.axisDirection,
     this.itemExtent,
+    this.layoutWeights,
     required super.devicePixelRatio,
   });
 
@@ -594,6 +1196,7 @@ class _CarouselMetrics extends FixedScrollMetrics {
     double? viewportDimension,
     AxisDirection? axisDirection,
     double? itemExtent,
+    List<int>? layoutWeights,
     double? devicePixelRatio,
   }) {
     return _CarouselMetrics(
@@ -603,6 +1206,7 @@ class _CarouselMetrics extends FixedScrollMetrics {
       viewportDimension: viewportDimension ?? (hasViewportDimension ? this.viewportDimension : null),
       axisDirection: axisDirection ?? this.axisDirection,
       itemExtent: itemExtent ?? this.itemExtent,
+      layoutWeights: layoutWeights ?? this.layoutWeights,
       devicePixelRatio: devicePixelRatio ?? this.devicePixelRatio,
     );
   }
@@ -611,6 +1215,11 @@ class _CarouselMetrics extends FixedScrollMetrics {
   ///
   /// Used to compute the first item from the current [pixels].
   final double? itemExtent;
+
+  /// The fraction of the viewport that the first item occupies.
+  ///
+  /// Used to compute [item] from the current [pixels].
+  final List<int>? layoutWeights;
 }
 
 class _CarouselPosition extends ScrollPositionWithSingleContext implements _CarouselMetrics {
@@ -618,9 +1227,13 @@ class _CarouselPosition extends ScrollPositionWithSingleContext implements _Caro
     required super.physics,
     required super.context,
     this.initialItem = 0,
-    required double itemExtent,
+    double? itemExtent,
+    List<int>? layoutWeights,
     super.oldPosition,
-  }) : _itemExtent = itemExtent,
+  }) : assert(layoutWeights != null && itemExtent == null
+       || layoutWeights == null && itemExtent != null),
+       _layoutWeights = layoutWeights,
+       _itemExtent = itemExtent,
        _itemToShowOnStartup = initialItem.toDouble(),
        super(
          initialPixels: null
@@ -634,6 +1247,16 @@ class _CarouselPosition extends ScrollPositionWithSingleContext implements _Caro
   double? _cachedItem;
 
   @override
+  List<int>? get layoutWeights => _layoutWeights;
+  List<int>? _layoutWeights;
+  set layoutWeights(List<int>? value) {
+    if (_layoutWeights == value) {
+      return;
+    }
+    _layoutWeights = value;
+  }
+
+  @override
   double? get itemExtent => _itemExtent;
   double? _itemExtent;
   set itemExtent(double? value) {
@@ -645,8 +1268,12 @@ class _CarouselPosition extends ScrollPositionWithSingleContext implements _Caro
 
   double getItemFromPixels(double pixels, double viewportDimension) {
     assert(viewportDimension > 0.0);
-    final double fraction = itemExtent! / viewportDimension;
-
+    double fraction;
+    if (itemExtent != null) {
+      fraction = itemExtent! / viewportDimension;
+    } else { // If itemExtent is null, layoutWeights cannot be null.
+      fraction = layoutWeights!.first / layoutWeights!.sum;
+    }
     final double actual = math.max(0.0, pixels) / (viewportDimension * fraction);
     final double round = actual.roundToDouble();
     if ((actual - round).abs() < precisionErrorTolerance) {
@@ -656,8 +1283,12 @@ class _CarouselPosition extends ScrollPositionWithSingleContext implements _Caro
   }
 
   double getPixelsFromItem(double item) {
-    final double fraction = itemExtent! / viewportDimension;
-
+    double fraction;
+    if (itemExtent != null) {
+      fraction = itemExtent! / viewportDimension;
+    } else { // If itemExtent is null, layoutWeights cannot be null.
+      fraction = layoutWeights!.first / layoutWeights!.sum;
+    }
     return item * viewportDimension * fraction;
   }
 
@@ -708,6 +1339,7 @@ class _CarouselPosition extends ScrollPositionWithSingleContext implements _Caro
       viewportDimension: viewportDimension ?? (hasViewportDimension ? this.viewportDimension : null),
       axisDirection: axisDirection ?? this.axisDirection,
       itemExtent: itemExtent ?? this.itemExtent,
+      layoutWeights: layoutWeights ?? this.layoutWeights,
       devicePixelRatio: devicePixelRatio ?? this.devicePixelRatio,
     );
   }
@@ -742,13 +1374,27 @@ class CarouselController extends ScrollController {
   @override
   ScrollPosition createScrollPosition(ScrollPhysics physics, ScrollContext context, ScrollPosition? oldPosition) {
     assert(_carouselState != null);
+    final List<int>? weights = _carouselState!.weights;
     final double? itemExtent = _carouselState!.itemExtent;
+    int expandedItem = initialItem;
+
+    if (weights != null && !_carouselState!.allowFullyExpand) {
+      int smallerWeights = 0;
+      for (final int weight in weights) {
+        if (weight == weights.max) {
+          break;
+        }
+        smallerWeights += 1;
+      }
+      expandedItem -= smallerWeights;
+    }
 
     return _CarouselPosition(
       physics: physics,
       context: context,
-      initialItem: initialItem,
-      itemExtent: itemExtent!,
+      initialItem: expandedItem,
+      itemExtent: itemExtent,
+      layoutWeights: weights,
       oldPosition: oldPosition,
     );
   }
@@ -757,6 +1403,7 @@ class CarouselController extends ScrollController {
   void attach(ScrollPosition position) {
     super.attach(position);
     final _CarouselPosition carouselPosition = position as _CarouselPosition;
+    carouselPosition.layoutWeights = _carouselState!.weights;
     carouselPosition.itemExtent = _carouselState!.itemExtent;
   }
 }

--- a/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
+++ b/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
@@ -82,7 +82,7 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
         if (childCount != null && i > childCount - 1) {
           break;
         }
-        itemExtent = itemExtentBuilder!(i, _currentLayoutDimensions);
+        itemExtent = itemExtentBuilder!(i, currentLayoutDimensions);
         if (itemExtent == null) {
           break;
         }
@@ -226,7 +226,7 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
       double offset = 0.0;
       double? itemExtent;
       for (int i = 0; i < childManager.childCount; i++) {
-        itemExtent = itemExtentBuilder!(i, _currentLayoutDimensions);
+        itemExtent = itemExtentBuilder!(i, currentLayoutDimensions);
         if (itemExtent == null) {
           break;
         }
@@ -248,7 +248,7 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
       if (childCount != null && index > childCount - 1) {
         break;
       }
-      itemExtent = callback(index, _currentLayoutDimensions);
+      itemExtent = callback(index, currentLayoutDimensions);
       if (itemExtent == null) {
         break;
       }
@@ -263,7 +263,7 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
     if (itemExtentBuilder == null) {
       extent = itemExtent!;
     } else {
-      extent = itemExtentBuilder!(index, _currentLayoutDimensions)!;
+      extent = itemExtentBuilder!(index, currentLayoutDimensions)!;
     }
     return constraints.asBoxConstraints(
       minExtent: extent,
@@ -271,7 +271,8 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
     );
   }
 
-  late SliverLayoutDimensions _currentLayoutDimensions;
+  @protected
+  late SliverLayoutDimensions currentLayoutDimensions;
 
   @override
   void performLayout() {
@@ -289,7 +290,7 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
     assert(remainingExtent >= 0.0);
     final double targetEndScrollOffset = scrollOffset + remainingExtent;
 
-    _currentLayoutDimensions = SliverLayoutDimensions(
+    currentLayoutDimensions = SliverLayoutDimensions(
         scrollOffset: constraints.scrollOffset,
         precedingScrollExtent: constraints.precedingScrollExtent,
         viewportMainAxisExtent: constraints.viewportMainAxisExtent,

--- a/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
+++ b/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
@@ -82,7 +82,7 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
         if (childCount != null && i > childCount - 1) {
           break;
         }
-        itemExtent = itemExtentBuilder!(i, currentLayoutDimensions);
+        itemExtent = itemExtentBuilder!(i, _currentLayoutDimensions);
         if (itemExtent == null) {
           break;
         }
@@ -226,7 +226,7 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
       double offset = 0.0;
       double? itemExtent;
       for (int i = 0; i < childManager.childCount; i++) {
-        itemExtent = itemExtentBuilder!(i, currentLayoutDimensions);
+        itemExtent = itemExtentBuilder!(i, _currentLayoutDimensions);
         if (itemExtent == null) {
           break;
         }
@@ -248,7 +248,7 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
       if (childCount != null && index > childCount - 1) {
         break;
       }
-      itemExtent = callback(index, currentLayoutDimensions);
+      itemExtent = callback(index, _currentLayoutDimensions);
       if (itemExtent == null) {
         break;
       }
@@ -263,7 +263,7 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
     if (itemExtentBuilder == null) {
       extent = itemExtent!;
     } else {
-      extent = itemExtentBuilder!(index, currentLayoutDimensions)!;
+      extent = itemExtentBuilder!(index, _currentLayoutDimensions)!;
     }
     return constraints.asBoxConstraints(
       minExtent: extent,
@@ -271,8 +271,7 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
     );
   }
 
-  @protected
-  late SliverLayoutDimensions currentLayoutDimensions;
+  late SliverLayoutDimensions _currentLayoutDimensions;
 
   @override
   void performLayout() {
@@ -290,7 +289,7 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
     assert(remainingExtent >= 0.0);
     final double targetEndScrollOffset = scrollOffset + remainingExtent;
 
-    currentLayoutDimensions = SliverLayoutDimensions(
+    _currentLayoutDimensions = SliverLayoutDimensions(
         scrollOffset: constraints.scrollOffset,
         precedingScrollExtent: constraints.precedingScrollExtent,
         viewportMainAxisExtent: constraints.viewportMainAxisExtent,

--- a/packages/flutter/test/material/carousel_test.dart
+++ b/packages/flutter/test/material/carousel_test.dart
@@ -63,6 +63,7 @@ void main() {
               if (states.contains(WidgetState.focused)) {
                 return Colors.purple;
               }
+              return null;
             }),
             itemExtent: 200,
             children: List<Widget>.generate(10, (int index) {

--- a/packages/flutter/test/material/carousel_test.dart
+++ b/packages/flutter/test/material/carousel_test.dart
@@ -40,7 +40,7 @@ void main() {
     ));
   });
 
-    testWidgets('Carousel items customization', (WidgetTester tester) async {
+  testWidgets('Carousel items customization', (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
     final ThemeData theme = ThemeData();
 
@@ -145,8 +145,6 @@ void main() {
       ),
     );
 
-    // await tester.tap(find.text('Item 1'));
-    // await tester.tap(find.byKey(keys.elementAt(1)));
     final Finder item1 = find.byKey(keys.elementAt(1));
     await tester.tap(find.ancestor(of: item1, matching: find.byType(Stack)));
     await tester.pump();
@@ -174,7 +172,7 @@ void main() {
       )
     );
 
-    final Size viewportSize = MediaQuery.of(tester.element(find.byType(Carousel))).size;
+    final Size viewportSize = MediaQuery.sizeOf(tester.element(find.byType(Carousel)));
     expect(viewportSize, const Size(800, 600));
 
     expect(find.text('Item 0'), findsOneWidget);
@@ -213,7 +211,7 @@ void main() {
       )
     );
 
-    final Size viewportSize = MediaQuery.of(tester.element(find.byType(Carousel))).size;
+    final Size viewportSize = MediaQuery.sizeOf(tester.element(find.byType(Carousel)));
     expect(viewportSize, const Size(800, 600));
 
     expect(find.text('Item 5'), findsOneWidget);
@@ -229,6 +227,7 @@ void main() {
     expect(find.text('Item 4'), findsNothing);
     expect(find.text('Item 7'), findsNothing);
   });
+
   testWidgets('Carousel respects itemSnapping', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(

--- a/packages/flutter/test/material/carousel_test.dart
+++ b/packages/flutter/test/material/carousel_test.dart
@@ -1,0 +1,461 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Carousel defaults', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData();
+    final ColorScheme colorScheme = theme.colorScheme;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: theme,
+        home: Scaffold(
+          body: Carousel(
+            itemExtent: 200,
+            children: List<Widget>.generate(10, (int index) {
+              return Center(child: Text('Item $index'));
+            }),
+          ),
+        ),
+      ),
+    );
+
+    final Finder carouselMaterial = find.descendant(
+      of: find.byType(Carousel),
+      matching: find.byType(Material),
+    ).first;
+
+    final Material material = tester.widget<Material>(carouselMaterial);
+    expect(material.clipBehavior, Clip.antiAlias);
+    expect(material.color, colorScheme.surface);
+    expect(material.elevation, 0.0);
+    expect(material.shape, const RoundedRectangleBorder(
+      borderRadius: BorderRadius.all(Radius.circular(28.0))
+    ));
+  });
+
+    testWidgets('Carousel items customization', (WidgetTester tester) async {
+    final GlobalKey key = GlobalKey();
+    final ThemeData theme = ThemeData();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: theme,
+        home: Scaffold(
+          body: Carousel(
+            padding: const EdgeInsets.all(20.0),
+            backgroundColor: Colors.amber,
+            elevation: 10.0,
+            shape: const StadiumBorder(),
+            overlayColor: WidgetStateProperty.resolveWith((Set<WidgetState> states) {
+              if (states.contains(WidgetState.pressed)) {
+                return Colors.yellow;
+              }
+              if (states.contains(WidgetState.hovered)) {
+                return Colors.red;
+              }
+              if (states.contains(WidgetState.focused)) {
+                return Colors.purple;
+              }
+            }),
+            itemExtent: 200,
+            children: List<Widget>.generate(10, (int index) {
+              if (index == 0) {
+                return Center(
+                  key: key,
+                  child: Center(child: Text('Item $index')),
+                );
+              }
+              return Center(child: Text('Item $index'));
+            }),
+          ),
+        ),
+      ),
+    );
+
+    final Finder carouselMaterial = find.descendant(
+      of: find.byType(Carousel),
+      matching: find.byType(Material),
+    ).first;
+
+    expect(tester.getSize(carouselMaterial).width, 200 - 20 - 20); // Padding is 20 on both side.
+    final Material material = tester.widget<Material>(carouselMaterial);
+    expect(material.color, Colors.amber);
+    expect(material.elevation, 10.0);
+    expect(material.shape, const StadiumBorder());
+
+    RenderObject inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures');
+
+    // On hovered.
+    final TestGesture gesture = await _pointGestureToCarouselItem(tester, key);
+    await tester.pumpAndSettle();
+    expect(inkFeatures, paints..rect(color: Colors.red.withOpacity(1.0)));
+
+    // On pressed.
+    await tester.pumpAndSettle();
+    await gesture.down(tester.getCenter(find.byKey(key)));
+    await tester.pumpAndSettle();
+    inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures');
+    expect(inkFeatures, paints..rect()..rect(color: Colors.yellow.withOpacity(1.0)));
+
+    await tester.pumpAndSettle();
+    await gesture.up();
+    await gesture.removePointer();
+
+    // On focused.
+    final Element inkWellElement = tester.element(find.descendant(of: carouselMaterial, matching: find.byType(InkWell)));
+    expect(inkWellElement.widget, isA<InkWell>());
+    final InkWell inkWell = inkWellElement.widget as InkWell;
+
+    const MaterialState state = MaterialState.focused;
+
+    // Check overlay color in focused state
+    expect(inkWell.overlayColor?.resolve(<WidgetState>{state}), Colors.purple);
+  });
+
+  testWidgets('Carousel respect onTap', (WidgetTester tester) async {
+    final List<GlobalKey> keys = List<GlobalKey>.generate(10, (_) => GlobalKey());
+    final ThemeData theme = ThemeData();
+    int tapIndex = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: theme,
+        home: Scaffold(
+          body: Carousel(
+            itemExtent: 50,
+            onTap: (int index) {
+              tapIndex = index;
+            },
+            children: List<Widget>.generate(10, (int index) {
+              return Center(
+                key: keys.elementAt(index),
+                child: Text('Item $index'),
+              );
+            }),
+          ),
+        ),
+      ),
+    );
+
+    // await tester.tap(find.text('Item 1'));
+    // await tester.tap(find.byKey(keys.elementAt(1)));
+    final Finder item1 = find.byKey(keys.elementAt(1));
+    await tester.tap(find.ancestor(of: item1, matching: find.byType(Stack)));
+    await tester.pump();
+    expect(tapIndex, 1);
+
+    final Finder item2 = find.byKey(keys.elementAt(2));
+    await tester.tap(find.ancestor(of: item2, matching: find.byType(Stack)));
+    await tester.pump();
+    expect(tapIndex, 2);
+  });
+
+  testWidgets('Carousel layout (Uncontained layout)', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Carousel(
+            itemExtent: 250,
+            children: List<Widget>.generate(10, (int index) {
+              return Center(
+                child: Text('Item $index'),
+              );
+            }),
+          ),
+        ),
+      )
+    );
+
+    final Size viewportSize = MediaQuery.of(tester.element(find.byType(Carousel))).size;
+    expect(viewportSize, const Size(800, 600));
+
+    expect(find.text('Item 0'), findsOneWidget);
+    final Rect rect0 = tester.getRect(getItem(0));
+    expect(rect0, const Rect.fromLTRB(0.0, 0.0, 250.0, 600.0));
+
+    expect(find.text('Item 1'), findsOneWidget);
+    final Rect rect1 = tester.getRect(getItem(1));
+    expect(rect1, const Rect.fromLTRB(250.0, 0.0, 500.0, 600.0));
+
+    expect(find.text('Item 2'), findsOneWidget);
+    final Rect rect2 = tester.getRect(getItem(2));
+    expect(rect2, const Rect.fromLTRB(500.0, 0.0, 750.0, 600.0));
+
+    expect(find.text('Item 3'), findsOneWidget);
+    final Rect rect3 = tester.getRect(getItem(3));
+    expect(rect3, const Rect.fromLTRB(750.0, 0.0, 800.0, 600.0));
+
+    expect(find.text('Item 4'), findsNothing);
+  });
+
+  testWidgets('CarouselController initialItem', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Carousel(
+            controller: CarouselController(initialItem: 5),
+            itemExtent: 400,
+            children: List<Widget>.generate(10, (int index) {
+              return Center(
+                child: Text('Item $index'),
+              );
+            }),
+          ),
+        ),
+      )
+    );
+
+    final Size viewportSize = MediaQuery.of(tester.element(find.byType(Carousel))).size;
+    expect(viewportSize, const Size(800, 600));
+
+    expect(find.text('Item 5'), findsOneWidget);
+    final Rect rect5 = tester.getRect(getItem(5));
+    // Item width is 400.
+    expect(rect5, const Rect.fromLTRB(0.0, 0.0, 400.0, 600.0));
+
+    expect(find.text('Item 6'), findsOneWidget);
+    final Rect rect6 = tester.getRect(getItem(6));
+    // Item width is 400.
+    expect(rect6, const Rect.fromLTRB(400.0, 0.0, 800.0, 600.0));
+
+    expect(find.text('Item 4'), findsNothing);
+    expect(find.text('Item 7'), findsNothing);
+  });
+  testWidgets('Carousel respects itemSnapping', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Carousel(
+            itemSnapping: true,
+            itemExtent: 300,
+            children: List<Widget>.generate(10, (int index) {
+              return Center(
+                child: Text('Item $index'),
+              );
+            }),
+          ),
+        ),
+      )
+    );
+
+    void checkOriginalExpectations() {
+      expect(getItem(0), findsOneWidget);
+      expect(getItem(1), findsOneWidget);
+      expect(getItem(2), findsOneWidget);
+      expect(getItem(3), findsNothing);
+    }
+
+    checkOriginalExpectations();
+
+    // Snap back to the original item.
+    await tester.drag(getItem(0), const Offset(-150, 0));
+    await tester.pumpAndSettle();
+
+    checkOriginalExpectations();
+
+    // Snap back to the original item.
+    await tester.drag(getItem(0), const Offset(100, 0));
+    await tester.pumpAndSettle();
+
+    checkOriginalExpectations();
+
+    // Snap to the next item.
+    await tester.drag(getItem(0), const Offset(-200, 0));
+    await tester.pumpAndSettle();
+
+    expect(getItem(0), findsNothing);
+    expect(getItem(1), findsOneWidget);
+    expect(getItem(2), findsOneWidget);
+    expect(getItem(3), findsOneWidget);
+  });
+
+  testWidgets('Carousel respect itemSnapping when fling', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Carousel(
+            itemSnapping: true,
+            itemExtent: 300,
+            children: List<Widget>.generate(10, (int index) {
+              return Center(
+                child: Text('Item $index'),
+              );
+            }),
+          ),
+        ),
+      )
+    );
+
+    // Show item 0, 1, and 2.
+    expect(getItem(0), findsOneWidget);
+    expect(getItem(1), findsOneWidget);
+    expect(getItem(2), findsOneWidget);
+    expect(getItem(3), findsNothing);
+
+    // Snap to the next item. Show item 1, 2 and 3.
+    await tester.fling(getItem(0), const Offset(-100, 0), 800);
+    await tester.pumpAndSettle();
+
+    expect(getItem(0), findsNothing);
+    expect(getItem(1), findsOneWidget);
+    expect(getItem(2), findsOneWidget);
+    expect(getItem(3), findsOneWidget);
+    expect(getItem(4), findsNothing);
+
+    // Snap to the next item. Show item 2, 3 and 4.
+    await tester.fling(getItem(1), const Offset(-100, 0), 800);
+    await tester.pumpAndSettle();
+
+    expect(getItem(0), findsNothing);
+    expect(getItem(1), findsNothing);
+    expect(getItem(2), findsOneWidget);
+    expect(getItem(3), findsOneWidget);
+    expect(getItem(4), findsOneWidget);
+    expect(getItem(5), findsNothing);
+
+    // Fling back to the previous item. Show item 1, 2 and 3.
+    await tester.fling(getItem(2), const Offset(100, 0), 800);
+    await tester.pumpAndSettle();
+
+    expect(getItem(1), findsOneWidget);
+    expect(getItem(2), findsOneWidget);
+    expect(getItem(3), findsOneWidget);
+    expect(getItem(4), findsNothing);
+  });
+
+  testWidgets('Carousel respects scrollingDirection: Axis.vertical', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Carousel(
+            itemExtent: 200,
+            padding: EdgeInsets.zero,
+            scrollDirection: Axis.vertical,
+            children: List<Widget>.generate(10, (int index) {
+              return Center(
+                child: Text('Item $index'),
+              );
+            }),
+          ),
+        ),
+      )
+    );
+    await tester.pumpAndSettle();
+
+    expect(getItem(0), findsOneWidget);
+    expect(getItem(1), findsOneWidget);
+    expect(getItem(2), findsOneWidget);
+    expect(getItem(3), findsNothing);
+    final Rect rect0 = tester.getRect(getItem(0));
+    // Item width is 200 of the viewport.
+    expect(rect0, const Rect.fromLTRB(0.0, 0.0, 800.0, 200.0));
+
+    // Simulate a scroll up
+    await tester.drag(find.byType(Carousel), const Offset(0, -200), kind: PointerDeviceKind.trackpad);
+    await tester.pumpAndSettle();
+    expect(getItem(0), findsNothing);
+    expect(getItem(3), findsOneWidget);
+  });
+
+  testWidgets('Carousel respects reverse', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Carousel(
+            itemExtent: 200,
+            reverse: true,
+            padding: EdgeInsets.zero,
+            children: List<Widget>.generate(10, (int index) {
+              return Center(
+                child: Text('Item $index'),
+              );
+            }),
+          ),
+        ),
+      )
+    );
+    await tester.pumpAndSettle();
+
+    expect(getItem(0), findsOneWidget);
+    final Rect rect0 = tester.getRect(getItem(0));
+    // Item 0 should be placed on the end of the screen.
+    expect(rect0, const Rect.fromLTRB(600.0, 0.0, 800.0, 600.0));
+
+    expect(getItem(1), findsOneWidget);
+    final Rect rect1 = tester.getRect(getItem(1));
+    // Item 1 should be placed before item 0.
+    expect(rect1, const Rect.fromLTRB(400.0, 0.0, 600.0, 600.0));
+
+    expect(getItem(2), findsOneWidget);
+    final Rect rect2 = tester.getRect(getItem(2));
+    // Item 2 should be placed before item 1.
+    expect(rect2, const Rect.fromLTRB(200.0, 0.0, 400.0, 600.0));
+
+    expect(getItem(3), findsOneWidget);
+    final Rect rect3 = tester.getRect(getItem(3));
+    // Item 3 should be placed before item 2.
+    expect(rect3, const Rect.fromLTRB(0.0, 0.0, 200.0, 600.0));
+  });
+
+  testWidgets('Carousel respects shrinkExtent', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Carousel(
+            itemExtent: 350,
+            shrinkExtent: 300,
+            children: List<Widget>.generate(10, (int index) {
+              return Center(
+                child: Text('Item $index'),
+              );
+            }),
+          ),
+        ),
+      )
+    );
+    await tester.pumpAndSettle();
+
+    final Rect rect0 = tester.getRect(getItem(0));
+    expect(rect0, const Rect.fromLTRB(0.0, 0.0, 350.0, 600.0));
+
+    final Rect rect1 = tester.getRect(getItem(1));
+    expect(rect1, const Rect.fromLTRB(350.0, 0.0, 700.0, 600.0));
+
+    final Rect rect2 = tester.getRect(getItem(2));
+    // The extent of item 2 is 300, and only 100 is on screen.
+    expect(rect2, const Rect.fromLTRB(700.0, 0.0, 1000.0, 600.0));
+
+    await tester.drag(find.byType(Carousel), const Offset(-50, 0), kind: PointerDeviceKind.trackpad);
+    await tester.pump();
+    // The item 0 should be pinned and has a size change from 350 to 50.
+    expect(tester.getRect(getItem(0)), const Rect.fromLTRB(0.0, 0.0, 300.0, 600.0));
+    // Keep dragging to left, extent of item 0 won't change (still 300) and part of item 0 will
+    // be off screen.
+    await tester.drag(find.byType(Carousel), const Offset(-50, 0), kind: PointerDeviceKind.trackpad);
+    await tester.pump();
+    expect(tester.getRect(getItem(0)), const Rect.fromLTRB(-50, 0.0, 250, 600));
+  });
+}
+
+Finder getItem(int index) {
+  return find.descendant(of: find.byType(Carousel), matching: find.ancestor(of: find.text('Item $index'), matching: find.byType(Padding)));
+}
+
+Future<TestGesture> _pointGestureToCarouselItem(WidgetTester tester, GlobalKey key) async {
+  final Offset center = tester.getCenter(find.byKey(key));
+  final TestGesture gesture = await tester.createGesture(
+    kind: PointerDeviceKind.mouse,
+  );
+
+  // On hovered.
+  await gesture.addPointer();
+  await gesture.moveTo(center);
+  return gesture;
+}

--- a/packages/flutter/test/material/carousel_test.dart
+++ b/packages/flutter/test/material/carousel_test.dart
@@ -194,6 +194,67 @@ void main() {
     expect(find.text('Item 4'), findsNothing);
   });
 
+  testWidgets('Carousel.weighted layout', (WidgetTester tester) async {
+    Widget buildCarousel({ required List<int> weights }) {
+      return MaterialApp(
+        home: Scaffold(
+          body: Carousel.weighted(
+            layoutWeights: weights,
+            children: List<Widget>.generate(10, (int index) {
+              return Center(
+                child: Text('Item $index'),
+              );
+            }),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildCarousel(weights: <int>[4,3,2,1]));
+
+    final Size viewportSize = MediaQuery.of(tester.element(find.byType(Carousel))).size;
+    expect(viewportSize, const Size(800, 600));
+
+    expect(find.text('Item 0'), findsOneWidget);
+    Rect rect0 = tester.getRect(getItem(0));
+    // Item width is 4/10 of the viewport.
+    expect(rect0, const Rect.fromLTRB(0.0, 0.0, 320.0, 600.0));
+
+    expect(find.text('Item 1'), findsOneWidget);
+    Rect rect1 = tester.getRect(getItem(1));
+    // Item width is 3/10 of the viewport.
+    expect(rect1, const Rect.fromLTRB(320.0, 0.0, 560.0, 600.0));
+
+    expect(find.text('Item 2'), findsOneWidget);
+    final Rect rect2 = tester.getRect(getItem(2));
+    // Item width is 2/10 of the viewport.
+    expect(rect2, const Rect.fromLTRB(560.0, 0.0, 720.0, 600.0));
+
+    expect(find.text('Item 3'), findsOneWidget);
+    final Rect rect3 = tester.getRect(getItem(3));
+    // Item width is 1/10 of the viewport.
+    expect(rect3, const Rect.fromLTRB(720.0, 0.0, 800.0, 600.0));
+
+    expect(find.text('Item 4'), findsNothing);
+
+    // Test shorter weight list.
+    await tester.pumpWidget(buildCarousel(weights: <int>[7,1]));
+    await tester.pumpAndSettle();
+    expect(viewportSize, const Size(800, 600));
+
+    expect(find.text('Item 0'), findsOneWidget);
+    rect0 = tester.getRect(getItem(0));
+    // Item width is 7/8 of the viewport.
+    expect(rect0, const Rect.fromLTRB(0.0, 0.0, 700.0, 600.0));
+
+    expect(find.text('Item 1'), findsOneWidget);
+    rect1 = tester.getRect(getItem(1));
+    // Item width is 1/8 of the viewport.
+    expect(rect1, const Rect.fromLTRB(700.0, 0.0, 800.0, 600.0));
+
+    expect(find.text('Item 2'), findsNothing);
+  });
+
   testWidgets('CarouselController initialItem', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
@@ -225,6 +286,79 @@ void main() {
     expect(rect6, const Rect.fromLTRB(400.0, 0.0, 800.0, 600.0));
 
     expect(find.text('Item 4'), findsNothing);
+    expect(find.text('Item 7'), findsNothing);
+  });
+
+  testWidgets('Carousel.weighted respects CarouselController.initialItem', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Carousel.weighted(
+            controller: CarouselController(initialItem: 5),
+            layoutWeights: const <int>[7,1],
+            children: List<Widget>.generate(10, (int index) {
+              return Center(
+                child: Text('Item $index'),
+              );
+            }),
+          ),
+        ),
+      )
+    );
+
+    final Size viewportSize = MediaQuery.of(tester.element(find.byType(Carousel))).size;
+    expect(viewportSize, const Size(800, 600));
+
+    expect(find.text('Item 5'), findsOneWidget);
+    final Rect rect5 = tester.getRect(getItem(5));
+    // Item width is 7/8 of the viewport.
+    expect(rect5, const Rect.fromLTRB(0.0, 0.0, 700.0, 600.0));
+
+    expect(find.text('Item 6'), findsOneWidget);
+    final Rect rect6 = tester.getRect(getItem(6));
+    // Item width is 1/8 of the viewport.
+    expect(rect6, const Rect.fromLTRB(700.0, 0.0, 800.0, 600.0));
+
+    expect(find.text('Item 4'), findsNothing);
+    expect(find.text('Item 7'), findsNothing);
+  });
+
+  testWidgets('The initialItem should be the first item with expanded size(max extent)', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Carousel.weighted(
+            controller: CarouselController(initialItem: 5),
+            layoutWeights: const <int>[1,8,1],
+            children: List<Widget>.generate(10, (int index) {
+              return Center(
+                child: Text('Item $index'),
+              );
+            }),
+          ),
+        ),
+      )
+    );
+
+    final Size viewportSize = MediaQuery.of(tester.element(find.byType(Carousel))).size;
+    expect(viewportSize, const Size(800, 600));
+
+    // Item 5 should have be the expanded item.
+    expect(find.text('Item 5'), findsOneWidget);
+    final Rect rect5 = tester.getRect(getItem(5));
+    // Item width is 8/10 of the viewport.
+    expect(rect5, const Rect.fromLTRB(80.0, 0.0, 720.0, 600.0));
+
+    expect(find.text('Item 6'), findsOneWidget);
+    final Rect rect6 = tester.getRect(getItem(6));
+    // Item width is 1/10 of the viewport.
+    expect(rect6, const Rect.fromLTRB(720.0, 0.0, 800.0, 600.0));
+
+    expect(find.text('Item 4'), findsOneWidget);
+    final Rect rect4 = tester.getRect(getItem(4));
+    // Item width is 1/10 of the viewport.
+    expect(rect4, const Rect.fromLTRB(0.0, 0.0, 80.0, 600.0));
+
     expect(find.text('Item 7'), findsNothing);
   });
 
@@ -274,6 +408,54 @@ void main() {
     expect(getItem(1), findsOneWidget);
     expect(getItem(2), findsOneWidget);
     expect(getItem(3), findsOneWidget);
+  });
+
+  testWidgets('Carousel.weighted respects itemSnapping', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Carousel.weighted(
+            itemSnapping: true,
+            allowFullyExpand: false,
+            layoutWeights: const <int>[1,7],
+            children: List<Widget>.generate(10, (int index) {
+              return Center(
+                child: Text('Item $index'),
+              );
+            }),
+          ),
+        ),
+      )
+    );
+
+    void checkOriginalExpectations() {
+      expect(getItem(0), findsOneWidget);
+      expect(getItem(1), findsOneWidget);
+      expect(getItem(2), findsNothing);
+    }
+
+    checkOriginalExpectations();
+
+    // Snap back to the original item.
+    await tester.drag(getItem(0), const Offset(-20, 0));
+    await tester.pumpAndSettle();
+
+    checkOriginalExpectations();
+
+    // Snap back to the original item.
+    await tester.drag(getItem(0), const Offset(50, 0));
+    await tester.pumpAndSettle();
+
+    checkOriginalExpectations();
+
+    // Snap to the next item.
+    await tester.drag(getItem(0), const Offset(-70, 0));
+    await tester.pumpAndSettle();
+
+    expect(getItem(0), findsNothing);
+    expect(getItem(1), findsOneWidget);
+    expect(getItem(2), findsOneWidget);
+    expect(getItem(3), findsNothing);
   });
 
   testWidgets('Carousel respect itemSnapping when fling', (WidgetTester tester) async {
@@ -328,6 +510,60 @@ void main() {
     expect(getItem(2), findsOneWidget);
     expect(getItem(3), findsOneWidget);
     expect(getItem(4), findsNothing);
+  });
+
+  testWidgets('Carousel.weighted respect itemSnapping when fling', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Carousel.weighted(
+            itemSnapping: true,
+            allowFullyExpand: false,
+            layoutWeights: const <int>[1,8,1],
+            children: List<Widget>.generate(10, (int index) {
+              return Center(
+                child: Text('$index'),
+              );
+            }),
+          ),
+        ),
+      )
+    );
+    await tester.pumpAndSettle();
+
+    // Show item 0, 1, and 2.
+    expect(getItem(0), findsOneWidget);
+    expect(getItem(1), findsOneWidget);
+    expect(getItem(2), findsOneWidget);
+    expect(getItem(3), findsNothing);
+
+    // Should snap to item 2 because of a long drag(-100). Show item 2, 3 and 4.
+    await tester.fling(getItem(0), const Offset(-100, 0), 800);
+    await tester.pumpAndSettle();
+
+    expect(getItem(0), findsNothing);
+    expect(getItem(1), findsNothing);
+    expect(getItem(2), findsOneWidget);
+    expect(getItem(3), findsOneWidget);
+    expect(getItem(4), findsOneWidget);
+
+    // Fling to the next item (item 3). Show item 3, 4 and 5.
+    await tester.fling(getItem(2), const Offset(-50, 0), 800);
+    await tester.pumpAndSettle();
+
+    expect(getItem(2), findsNothing);
+    expect(getItem(3), findsOneWidget);
+    expect(getItem(4), findsOneWidget);
+    expect(getItem(5), findsOneWidget);
+
+    // Fling back to the previous item. Show item 2, 3 and 4.
+    await tester.fling(getItem(3), const Offset(50, 0), 800);
+    await tester.pumpAndSettle();
+
+    expect(getItem(2), findsOneWidget);
+    expect(getItem(3), findsOneWidget);
+    expect(getItem(4), findsOneWidget);
+    expect(getItem(5), findsNothing);
   });
 
   testWidgets('Carousel respects scrollingDirection: Axis.vertical', (WidgetTester tester) async {
@@ -441,6 +677,106 @@ void main() {
     await tester.drag(find.byType(Carousel), const Offset(-50, 0), kind: PointerDeviceKind.trackpad);
     await tester.pump();
     expect(tester.getRect(getItem(0)), const Rect.fromLTRB(-50, 0.0, 250, 600));
+  });
+
+  testWidgets('Carousel.weighted respects allowFullyExpand', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Carousel.weighted(
+            layoutWeights: const <int>[1,2,4,2,1],
+            itemSnapping: true,
+            children: List<Widget>.generate(10, (int index) {
+              return Center(
+                child: Text('Item $index'),
+              );
+            }),
+          ),
+        ),
+      )
+    );
+
+    // The initial item is item 0. To make sure the layout stays the same, the
+    // first item should be placed at the middle of the screen and there are some
+    // white space as if there are two more shinked items before the first item.
+    final Rect rect0 = tester.getRect(getItem(0));
+    expect(rect0, const Rect.fromLTRB(240.0, 0.0, 560.0, 600.0));
+
+    for (int i = 0; i < 7; i++) {
+      await tester.drag(find.byType(Carousel), const Offset(-80.0, 0.0));
+      await tester.pumpAndSettle();
+    }
+
+    // After scrolling the carousel 7 times, the last item(item 9) should be on
+    // the end of the screen.
+    expect(getItem(9), findsOneWidget);
+    expect(tester.getRect(getItem(9)), const Rect.fromLTRB(720.0, 0.0, 800.0, 600.0));
+
+    // Keep snapping twice. Item 9 should be fully expanded to the max size.
+    for (int i = 0; i < 2; i++) {
+      await tester.drag(find.byType(Carousel), const Offset(-80.0, 0.0));
+      await tester.pumpAndSettle();
+    }
+    expect(getItem(9), findsOneWidget);
+    expect(tester.getRect(getItem(9)), const Rect.fromLTRB(240.0, 0.0, 560.0, 600.0));
+  });
+
+  testWidgets('While scrolling, one more item will show at the end of the screen during items transition', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Carousel.weighted(
+            layoutWeights: const <int>[1,2,4,2,1],
+            allowFullyExpand: false,
+            children: List<Widget>.generate(10, (int index) {
+              return Center(
+                child: Text('Item $index'),
+              );
+            }),
+          ),
+        ),
+      )
+    );
+    await tester.pumpAndSettle();
+
+    for (int i = 0; i < 5; i++) {
+      expect(getItem(i), findsOneWidget);
+    }
+
+    // Drag the first item to the middle. So the progress for the first item size change
+    // is 50%, original width is 80.
+    await tester.drag(getItem(0), const Offset(-40.0, 0.0), kind: PointerDeviceKind.trackpad);
+    await tester.pump();
+    expect(tester.getRect(getItem(0)).width, 40.0);
+
+    // The size of item 1 is changing to the size of item 0, so the size of item 1
+    // now should be item1.originalExtent - 50% * (item1.extent - item0.extent).
+    // Item1 originally should be 2/(1+2+4+2+1) * 800 = 160.0.
+    expect(tester.getRect(getItem(1)).width, 160 - 0.5 * (160 - 80));
+
+    // The extent of item 2 should be: item2.originalExtent - 50% * (item2.extent - item1.extent).
+    // the extent of item 2 originally should be 4/(1+2+4+2+1) * 800 = 320.0.
+    expect(tester.getRect(getItem(2)).width, 320 - 0.5 * (320 - 160));
+
+    // The extent of item 3 should be: item3.originalExtent + 50% * (item2.extent - item3.extent).
+    // the extent of item 3 originally should be 2/(1+2+4+2+1) * 800 = 160.0.
+    expect(tester.getRect(getItem(3)).width, 160 + 0.5 * (320 - 160));
+
+    // The extent of item 4 should be: item4.originalExtent + 50% * (item3.extent - item4.extent).
+    // the extent of item 4 originally should be 1/(1+2+4+2+1) * 800 = 80.0.
+    expect(tester.getRect(getItem(4)).width, 80 + 0.5 * (160 - 80));
+
+    // The sum of the first 5 items during transition is less than the screen width.
+    double sum = 0;
+    for (int i = 0; i < 5; i++) {
+      sum += tester.getRect(getItem(i)).width;
+    }
+    expect(sum, lessThan(MediaQuery.of(tester.element(find.byType(Carousel))).size.width));
+    final double difference = MediaQuery.of(tester.element(find.byType(Carousel))).size.width - sum;
+
+    // One more item should show on screen to fill the rest of the viewport.
+    expect(getItem(5), findsOneWidget);
+    expect(tester.getRect(getItem(5)).width, difference);
   });
 }
 


### PR DESCRIPTION
[Will merge Part 1 first and come to solve conflict here] This PR is to create `Carousel.weighted` so the size of each carousel item is based on its weight. While scrolling, item sizes are changing dynamically based on the scrolling progress.
https://github.com/flutter/flutter/assets/36861262/181472b0-6f8b-48e7-b191-ab5f7c88c0c8

CC: @piinks @goderbauer

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
